### PR TITLE
Workshop phone-sensor demo + remove V0.3 battery sensing

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -27,6 +27,7 @@ jobs:
           libraries: |
             - source-path: ./        # this library
             - name: PubSubClient     # HomeAssistant_MQTT example
+            - name: WebSockets       # PhoneSensors example (Markus Sattler)
           sketch-paths: |
             - examples
           enable-warnings-report: true

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ if (mist.batteryCritical()) {          // hysteresis built in
 Defaults: divider ratio 2.0, low = 3.45 V, critical = 3.20 V. Override with
 `setBatteryDivider()` / `setBatteryThresholds()`.
 
+> ⚠️ **Battery Kit V0.3:** the D1 divider reads `BATT+`, but the TPS2116 power
+> mux means the board runs off USB-C whenever it's plugged in — so D1 can't tell
+> "USB-only, no cell" from "on battery, dying," which caused false low-battery
+> shutdowns. Until V0.4 adds a USB-present pin, call `mist.disableBattery();`
+> before `begin()` to switch battery sensing off (every `battery*` call then
+> behaves as on a board with no cell). The networked examples already do this.
+
 ---
 
 ## 📚 Examples
@@ -117,7 +124,8 @@ Defaults: divider ratio 2.0, low = 3.45 V, critical = 3.20 V. Override with
 | `MistBlink` | Hello-world: 6 s ON / 3 s OFF cycle |
 | `MistDimming` | Organic "breathing" mist with `setLevel()` |
 | `WaterDetect` | Disc + water detection, auto-calibration, auto-recovery |
-| `WiFiPhoneControl` | Phone control via WiFi AP + web UI, graceful low-battery shutdown |
+| `WiFiPhoneControl` | Phone control via the board's own WiFi AP + web UI |
+| `PhoneSensors` | Drive the mist from a phone's mic/light/motion/face/music via a Cloudflare relay; sync many makers ([extras/phone-app](extras/phone-app)) |
 | `HomeAssistant_MQTT` | Native Home Assistant device via MQTT Discovery |
 | `Blink`, `SimpleControl`, `Ramping` | v1.0 basics (button toggle, level ramp) |
 | `ESPNow_Control` | Show-control via ESP-NOW (no router needed) |

--- a/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
+++ b/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
@@ -4,8 +4,12 @@
 // automatically (Settings > Devices > MQTT) as:
 //   * a dimmable "light" entity controlling the mist (HA's light card gives
 //     us an on/off toggle + brightness slider for free)
-//   * a battery voltage sensor + battery % sensor (Battery Kit)
 //   * a water/disc status sensor (from current sensing)
+//
+// NOTE: battery sensing is intentionally OFF on this branch — Battery Kit V0.3
+// can't tell USB-C power from a real cell on D1, so the reading is unreliable.
+// TODO(V0.4): re-add the battery % sensor + low-battery deep-sleep once the
+// board has a real USB-present sense pin.
 //
 // Requirements:
 //   * MQTT broker (the standard Mosquitto add-on) + MQTT integration in HA
@@ -20,7 +24,6 @@
 #include <MistMaker.h>
 #include <WiFi.h>
 #include <PubSubClient.h>
-#include <esp_sleep.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV03());
@@ -43,7 +46,6 @@ PubSubClient mqtt(wifi);
 
 char topicCmd[64], topicState[64], topicAvail[64], topicSensors[64];
 unsigned long lastSensorPub = 0;
-unsigned long lastBatteryCheck = 0;
 
 const char* waterName(MistSenseState s) {
   switch (s) {
@@ -63,11 +65,8 @@ void publishState() {
 }
 
 void publishSensors() {
-  char buf[160];
-  snprintf(buf, sizeof(buf),
-           "{\"battery_v\":%.2f,\"battery_pct\":%u,\"water\":\"%s\"}",
-           mist.readBatteryVolts(), mist.batteryPercent(),
-           waterName(mist.senseState()));
+  char buf[96];
+  snprintf(buf, sizeof(buf), "{\"water\":\"%s\"}", waterName(mist.senseState()));
   mqtt.publish(topicSensors, buf, true);
 }
 
@@ -87,15 +86,6 @@ void publishDiscovery() {
     "\"cmd_t\":\"%s\",\"stat_t\":\"%s\",\"avty_t\":\"%s\","
     "\"brightness\":true,\"bri_scl\":255,%s}",
     DEV_ID, topicCmd, topicState, topicAvail, devBuf);
-  mqtt.publish(topic, payload, true);
-
-  // Battery % sensor
-  snprintf(topic, sizeof(topic), "homeassistant/sensor/%s_batt/config", DEV_ID);
-  snprintf(payload, sizeof(payload),
-    "{\"name\":\"Mist Maker Battery\",\"uniq_id\":\"%s_batt\","
-    "\"stat_t\":\"%s\",\"avty_t\":\"%s\",\"dev_cla\":\"battery\","
-    "\"unit_of_meas\":\"%%\",\"val_tpl\":\"{{ value_json.battery_pct }}\",%s}",
-    DEV_ID, topicSensors, topicAvail, devBuf);
   mqtt.publish(topic, payload, true);
 
   // Water status sensor
@@ -144,19 +134,10 @@ void connectMqtt() {
   }
 }
 
-void gracefulPowerOff() {
-  Serial.println("[BATTERY] Critical - graceful shutdown.");
-  mqtt.publish(topicAvail, "offline", true); // tell HA we're going away
-  mqtt.disconnect();
-  mist.shutdown();
-  WiFi.disconnect(true);
-  delay(100);
-  esp_deep_sleep_start();
-}
-
 void setup() {
   Serial.begin(115200);
   delay(1000);
+  mist.disableBattery();   // V0.3: D1 can't tell USB from battery (see note up top)
   mist.begin();
 
   snprintf(topicCmd,     sizeof(topicCmd),     "mistmaker/%s/set",     DEV_ID);
@@ -188,11 +169,5 @@ void loop() {
     lastSensorPub = millis();
     mist.probe();
     publishSensors();
-  }
-
-  // Battery watchdog every 5 s.
-  if (millis() - lastBatteryCheck > 5000) {
-    lastBatteryCheck = millis();
-    if (mist.batteryState() == MIST_BATT_CRITICAL) gracefulPowerOff();
   }
 }

--- a/examples/MistBlink/MistBlink.ino
+++ b/examples/MistBlink/MistBlink.ino
@@ -23,6 +23,7 @@ const unsigned long OFF_TIME_MS = 3000;
 void setup() {
   Serial.begin(115200);
   delay(1000);
+  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
   mist.begin();
   Serial.println("MistBlink: 6 s ON / 3 s OFF");
 }

--- a/examples/MistDimming/MistDimming.ino
+++ b/examples/MistDimming/MistDimming.ino
@@ -25,6 +25,7 @@ const uint8_t LEVEL_FLOOR = 30;              // don't go fully off mid-breath
 void setup() {
   Serial.begin(115200);
   delay(1000);
+  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
   mist.begin();
   Serial.println("MistDimming: sine breathing, period 8 s");
 }

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -42,7 +42,7 @@ const char* WIFI_SSID  = "your-wifi";
 const char* WIFI_PASS  = "your-password";
 const char* RELAY_HOST = "mistmaker-relay.YOURNAME.workers.dev"; // no https://, no path
 const uint16_t RELAY_PORT = 443;
-const char* ROOM = "workshop";            // any phone in the same room controls this maker
+const char* ROOM = "workshop";            // any phone in this room controls this maker (letters/numbers only)
 
 WebSocketsClient ws;
 char deviceId[5];                          // last 2 bytes of MAC, e.g. "A4F1"
@@ -82,16 +82,18 @@ void sendStatus() {
 //   {"t":"set","target":"all"|"<id>","level":NN}   one or all makers
 //   {"t":"multi","levels":{"<id>":NN,...}}         a different level per maker
 void onCommand(const char* msg) {
-  if (strstr(msg, "\"set\"")) {
+  if (strstr(msg, "\"t\":\"set\"")) {
     const char* tgt = strstr(msg, "\"target\":\"");
     bool forMe = !tgt;                                  // no target = everyone
     if (tgt) {
-      tgt += 10;
-      forMe = !strncmp(tgt, "all\"", 4) || !strncmp(tgt, deviceId, strlen(deviceId));
+      tgt += 10;                                        // step over: "target":"
+      const size_t n = strlen(deviceId);
+      forMe = !strncmp(tgt, "all\"", 4) ||
+              (!strncmp(tgt, deviceId, n) && tgt[n] == '"');  // exact id, not a prefix
     }
     const char* lv = strstr(msg, "\"level\":");
     if (forMe && lv) applyLevel(atoi(lv + 8));
-  } else if (strstr(msg, "\"multi\"")) {
+  } else if (strstr(msg, "\"t\":\"multi\"")) {
     char key[10];
     snprintf(key, sizeof(key), "\"%s\":", deviceId);    // find "A4F1":NN
     const char* p = strstr(msg, key);
@@ -137,7 +139,11 @@ void setup() {
   WiFi.mode(WIFI_STA);
   WiFi.begin(WIFI_SSID, WIFI_PASS);
   Serial.printf("[WiFi] joining \"%s\"", WIFI_SSID);
-  while (WiFi.status() != WL_CONNECTED) { delay(300); Serial.print("."); }
+  unsigned long t0 = millis();
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(300); Serial.print(".");
+    if (millis() - t0 > 20000) { Serial.println(" timeout — restarting"); ESP.restart(); }
+  }
   Serial.printf(" ok — ip %s, rssi %d dBm\n", WiFi.localIP().toString().c_str(), WiFi.RSSI());
 
   // Join the room as a device. beginSSL with no cert = TLS without certificate

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -48,7 +48,8 @@ WebSocketsClient ws;
 char deviceId[5];                          // last 2 bytes of MAC, e.g. "A4F1"
 char deviceName[20];                       // "Mist-A4F1" (shown in the app + Serial)
 uint8_t level = 0;                         // current mist level 0-100
-unsigned long lastTick = 0;
+unsigned long lastTick = 0, lastCmd = 0, lastProbe = 0;
+const unsigned long CMD_TIMEOUT = 6000;    // mist off if no command this long (phone keepalive is ~2 s)
 
 const char* waterName(MistSenseState s) {
   switch (s) {
@@ -92,12 +93,12 @@ void onCommand(const char* msg) {
               (!strncmp(tgt, deviceId, n) && tgt[n] == '"');  // exact id, not a prefix
     }
     const char* lv = strstr(msg, "\"level\":");
-    if (forMe && lv) applyLevel(atoi(lv + 8));
+    if (forMe && lv) { lastCmd = millis(); applyLevel(atoi(lv + 8)); }
   } else if (strstr(msg, "\"t\":\"multi\"")) {
     char key[10];
     snprintf(key, sizeof(key), "\"%s\":", deviceId);    // find "A4F1":NN
     const char* p = strstr(msg, key);
-    if (p) applyLevel(atoi(p + strlen(key)));
+    if (p) { lastCmd = millis(); applyLevel(atoi(p + strlen(key))); }
   }
 }
 
@@ -107,7 +108,8 @@ void onWsEvent(WStype_t type, uint8_t* payload, size_t len) {
       Serial.println("[WS] connected — open the app on your phone to control me");
       break;
     case WStype_DISCONNECTED:
-      Serial.println("[WS] disconnected — will retry every 3 s");
+      Serial.println("[WS] disconnected — mist off, will retry every 3 s");
+      applyLevel(0);                                   // fail-safe: never atomize on a dead link
       break;
     case WStype_ERROR:
       Serial.println("[WS] error");
@@ -162,6 +164,22 @@ void setup() {
 
 void loop() {
   ws.loop();
+
+  // Fail-safe watchdog: a healthy link refreshes lastCmd every ~2 s (the phone's
+  // keepalive), so silence past CMD_TIMEOUT means the phone/relay/WiFi dropped —
+  // cut the mist rather than atomize forever.
+  if (level > 0 && millis() - lastCmd > CMD_TIMEOUT) {
+    Serial.println("[WATCHDOG] no commands — mist off");
+    applyLevel(0);
+  }
+
+  // Re-probe water/disc every 30 s so the app's status stays live, and never
+  // keep driving a missing or disconnected disc.
+  if (millis() - lastProbe > 30000) {
+    lastProbe = millis();
+    MistSenseState s = mist.probe();
+    if (s == MIST_DISC_MISSING || s == MIST_DISC_DISCONNECTED) applyLevel(0);
+  }
 
   // Once a second: report status to the app AND print a Serial heartbeat.
   if (millis() - lastTick > 1000) {

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -1,0 +1,169 @@
+// PhoneSensors — drive the mist from your phone's sensors, over the internet.
+//
+// This is the "thin client" half of the phone-sensor demo. The phone web app
+// (see extras/phone-app/) does ALL the heavy lifting — mic, light, motion,
+// face tracking, audio FFT, and choreographing several makers at once. Each
+// mist maker just runs this one sketch: it joins a Cloudflare "room" over a
+// secure WebSocket, waits for a mist level (0-100), and reports its status
+// back. Flash the SAME sketch to every board; each one names itself from its
+// MAC address so the phone can tell them apart.
+//
+// Why the cloud and not the board's own WiFi page? Phone sensors (mic, motion,
+// camera) only work on an HTTPS "secure" page, which the board can't serve over
+// its local AP. Hosting the app on Cloudflare gives every phone secure sensor
+// access with no certificate warnings. Because mist responds slowly (hundreds
+// of ms), cloud round-trip jitter is invisible — so all makers simply join the
+// same room and the phone keeps them in sync. No ESP-NOW channel juggling.
+//
+// DEBUGGING: open Serial Monitor at 115200. The board prints its name, WiFi +
+// relay status, every level change, and a status line each second. The same
+// status (level, current, water, signal) shows live in the web app's MAKERS
+// panel, so you can watch a board from USB or from the phone.
+//
+// Setup:
+//   1. Deploy the relay + app once (extras/phone-app/README.md), note its URL.
+//   2. Fill in WIFI_SSID / WIFI_PASS / RELAY_HOST below.
+//   3. Flash. Open the app URL on your phone. Your maker appears in the list.
+//
+// Library: MistMaker >= 1.1.0  +  "WebSockets" by Markus Sattler (Library Mgr)
+// Board:   Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
+
+#include <MistMaker.h>
+#include <WiFi.h>
+#include <WebSocketsClient.h>
+
+// ---- Select your board (uncomment exactly ONE) ----
+MistMaker mist(MistMakerBatteryKitV03());
+// MistMaker mist(MistMakerExtensionV01());
+// MistMaker mist(MistMakerBlockKitV01());
+
+// ---- Your WiFi + your deployed relay ----
+const char* WIFI_SSID  = "your-wifi";
+const char* WIFI_PASS  = "your-password";
+const char* RELAY_HOST = "mistmaker-relay.YOURNAME.workers.dev"; // no https://, no path
+const uint16_t RELAY_PORT = 443;
+const char* ROOM = "workshop";            // any phone in the same room controls this maker
+
+WebSocketsClient ws;
+char deviceId[5];                          // last 2 bytes of MAC, e.g. "A4F1"
+char deviceName[20];                       // "Mist-A4F1" (shown in the app + Serial)
+uint8_t level = 0;                         // current mist level 0-100
+unsigned long lastTick = 0;
+
+const char* waterName(MistSenseState s) {
+  switch (s) {
+    case MIST_WATER_OK:          return "ok";
+    case MIST_WATER_LOW:         return "low";
+    case MIST_DISC_MISSING:      return "no_disc";
+    case MIST_DISC_DISCONNECTED: return "disconnected";
+    default:                     return "unknown";
+  }
+}
+
+// level is a 0-100 percentage; the library caps real PWM duty at 50% internally,
+// so 100 here is full mist, not 100% duty.
+void applyLevel(int pct) {
+  pct = constrain(pct, 0, 100);
+  if (pct == level) return;                // ignore no-op commands
+  level = pct;
+  mist.setLevel((uint16_t)level * 255 / 100);
+  Serial.printf("[CMD] mist level -> %u%%\n", level);   // serial-debug each change
+}
+
+void sendStatus() {
+  char buf[160];
+  snprintf(buf, sizeof(buf),
+    "{\"t\":\"status\",\"level\":%u,\"current_ma\":%.0f,\"water\":\"%s\",\"rssi\":%d}",
+    level, mist.readCurrentMa(20), waterName(mist.senseState()), WiFi.RSSI());
+  ws.sendTXT(buf);
+}
+
+// Commands from the phone:
+//   {"t":"set","target":"all"|"<id>","level":NN}   one or all makers
+//   {"t":"multi","levels":{"<id>":NN,...}}         a different level per maker
+void onCommand(const char* msg) {
+  if (strstr(msg, "\"set\"")) {
+    const char* tgt = strstr(msg, "\"target\":\"");
+    bool forMe = !tgt;                                  // no target = everyone
+    if (tgt) {
+      tgt += 10;
+      forMe = !strncmp(tgt, "all\"", 4) || !strncmp(tgt, deviceId, strlen(deviceId));
+    }
+    const char* lv = strstr(msg, "\"level\":");
+    if (forMe && lv) applyLevel(atoi(lv + 8));
+  } else if (strstr(msg, "\"multi\"")) {
+    char key[10];
+    snprintf(key, sizeof(key), "\"%s\":", deviceId);    // find "A4F1":NN
+    const char* p = strstr(msg, key);
+    if (p) applyLevel(atoi(p + strlen(key)));
+  }
+}
+
+void onWsEvent(WStype_t type, uint8_t* payload, size_t len) {
+  switch (type) {
+    case WStype_CONNECTED:
+      Serial.println("[WS] connected — open the app on your phone to control me");
+      break;
+    case WStype_DISCONNECTED:
+      Serial.println("[WS] disconnected — will retry every 3 s");
+      break;
+    case WStype_ERROR:
+      Serial.println("[WS] error");
+      break;
+    case WStype_TEXT:
+      onCommand((const char*)payload);
+      break;
+    default: break;
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(500);
+  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
+  mist.begin();
+
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  snprintf(deviceId,   sizeof(deviceId),   "%02X%02X", mac[4], mac[5]);
+  snprintf(deviceName, sizeof(deviceName), "Mist-%s", deviceId);
+
+  Serial.println();
+  Serial.println("====================================");
+  Serial.printf ("  %s  (room: %s)\n", deviceName, ROOM);
+  Serial.printf ("  relay: %s\n", RELAY_HOST);
+  Serial.println("====================================");
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  Serial.printf("[WiFi] joining \"%s\"", WIFI_SSID);
+  while (WiFi.status() != WL_CONNECTED) { delay(300); Serial.print("."); }
+  Serial.printf(" ok — ip %s, rssi %d dBm\n", WiFi.localIP().toString().c_str(), WiFi.RSSI());
+
+  // Join the room as a device. beginSSL with no cert = TLS without certificate
+  // management (fine here — we send mist levels, not secrets).
+  char path[120];
+  snprintf(path, sizeof(path), "/ws?room=%s&role=device&id=%s&name=%s",
+           ROOM, deviceId, deviceName);
+  ws.beginSSL(RELAY_HOST, RELAY_PORT, path);
+  ws.onEvent(onWsEvent);
+  ws.setReconnectInterval(3000);
+  ws.enableHeartbeat(15000, 3000, 2);   // keep the link alive through idle gaps
+
+  mist.probe();   // initial disc + water check
+  Serial.println("[OK] ready. Watch this Serial log, or the app's MAKERS panel.");
+}
+
+void loop() {
+  ws.loop();
+
+  // Once a second: report status to the app AND print a Serial heartbeat.
+  if (millis() - lastTick > 1000) {
+    lastTick = millis();
+    const float ma = mist.readCurrentMa(20);
+    Serial.printf("[STAT] level=%u%%  current=%.0f mA  water=%s  wifi=%s(%d dBm)\n",
+                  level, ma, waterName(mist.senseState()),
+                  ws.isConnected() ? "relay-ok" : "no-relay", WiFi.RSSI());
+    if (ws.isConnected()) sendStatus();
+  }
+}

--- a/examples/WaterDetect/WaterDetect.ino
+++ b/examples/WaterDetect/WaterDetect.ino
@@ -51,6 +51,7 @@ const char* stateName(MistSenseState s) {
 void setup() {
   Serial.begin(115200);
   delay(1000);
+  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
   mist.begin();
 
   Serial.println("WaterDetect: 'c' = auto-calibrate (disc attached, in water)");

--- a/examples/WiFiPhoneControl/WiFiPhoneControl.ino
+++ b/examples/WiFiPhoneControl/WiFiPhoneControl.ino
@@ -4,13 +4,16 @@
 //   1. Power the board. On your phone, join WiFi "MistMaker" (password
 //      "mistmist" — change below).
 //   2. Open http://192.168.4.1 in any browser.
-//   3. Slide to dim, tap to toggle. Status (water, battery) updates live.
+//   3. Slide to dim, tap to toggle. Status (water) updates live.
 //
-// Built for workshops and demos: shows dimming, current-sense water
-// detection, and (on the Battery Kit) battery monitoring with a graceful
-// low-battery shutdown — when the pack gets critically low the firmware
-// stops the mist, disables the 5V boost rail, and deep-sleeps the ESP32
-// instead of browning out mid-mist.
+// Built for workshops and demos: dimming + current-sense water detection over
+// a self-hosted WiFi AP — no app, no router, no internet.
+//
+// NOTE: battery monitoring + low-battery deep-sleep are intentionally OFF on
+// this branch. Battery Kit V0.3 can't tell USB-C power from a real cell on D1,
+// so the reading is unreliable (it caused false brown-out shutdowns), and a
+// board that deep-sleeps is awkward to reflash mid-workshop. TODO(V0.4): re-add
+// battery brown-out + graceful deep-sleep once the board has a USB-present pin.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
 // Library: MistMaker >= 1.1.0
@@ -18,11 +21,10 @@
 #include <MistMaker.h>
 #include <WiFi.h>
 #include <WebServer.h>
-#include <esp_sleep.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV03());
-// MistMaker mist(MistMakerExtensionV01());   // no battery -> battery UI hides itself
+// MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
 
@@ -32,7 +34,6 @@ const char* AP_PASSWORD = "mistmist";   // >= 8 chars, or "" for an open network
 WebServer server(80);
 
 uint8_t targetLevel = 0;
-unsigned long lastBatteryCheck = 0;
 unsigned long lastProbe = 0;
 bool blocked = false;          // true when sense says we must not mist
 
@@ -64,7 +65,6 @@ const char PAGE[] PROGMEM = R"HTML(
          oninput="setLevel(this.value)">
  </div>
  <div class="row"><span>Water</span><span class="val" id="water">-</span></div>
- <div class="row" id="battrow"><span>Battery</span><span class="val" id="batt">-</span></div>
 </div>
 <script>
 let on=false;
@@ -77,9 +77,6 @@ function refresh(){fetch('/api/status').then(r=>r.json()).then(s=>{
  document.getElementById('lvl').value=s.level;
  document.getElementById('lvlv').textContent=Math.round(s.level/2.55)+'%';
  document.getElementById('water').textContent=s.water;
- if(s.batt_v>0.5){document.getElementById('batt').textContent=
-   s.batt_v.toFixed(2)+' V ('+s.batt_pct+'%)'+(s.batt_low?' LOW!':'');}
- else{document.getElementById('battrow').style.display='none';}
 });}
 setInterval(refresh,2000);refresh();
 </script></body></html>
@@ -96,13 +93,9 @@ const char* waterName(MistSenseState s) {
 }
 
 void handleStatus() {
-  char buf[192];
-  const float bv = mist.readBatteryVolts();
-  snprintf(buf, sizeof(buf),
-           "{\"level\":%u,\"water\":\"%s\",\"batt_v\":%.2f,"
-           "\"batt_pct\":%u,\"batt_low\":%s}",
-           mist.getLevel(), waterName(mist.senseState()), bv,
-           mist.batteryPercent(), mist.batteryLow() ? "true" : "false");
+  char buf[96];
+  snprintf(buf, sizeof(buf), "{\"level\":%u,\"water\":\"%s\"}",
+           mist.getLevel(), waterName(mist.senseState()));
   server.send(200, "application/json", buf);
 }
 
@@ -114,20 +107,10 @@ void handleSet() {
   server.send(200, "text/plain", "ok");
 }
 
-// ------------------------------------------------ graceful low-battery off
-void gracefulPowerOff() {
-  Serial.println("[BATTERY] Critical - graceful shutdown to avoid brown-out.");
-  mist.shutdown();           // mist off, boost rail off, LED off
-  WiFi.softAPdisconnect(true);
-  WiFi.mode(WIFI_OFF);
-  delay(100);
-  // Sleep forever; recharge + reset (or power cycle) wakes the board.
-  esp_deep_sleep_start();
-}
-
 void setup() {
   Serial.begin(115200);
   delay(1000);
+  mist.disableBattery();   // V0.3: D1 can't tell USB from battery (see note up top)
   mist.begin();
 
   WiFi.mode(WIFI_AP);
@@ -147,14 +130,6 @@ void setup() {
 
 void loop() {
   server.handleClient();
-
-  // Battery watchdog (Battery Kit): every 5 s. Critical -> graceful off.
-  if (millis() - lastBatteryCheck > 5000) {
-    lastBatteryCheck = millis();
-    MistBatteryState bs = mist.batteryState();
-    if (bs == MIST_BATT_CRITICAL) gracefulPowerOff();
-    if (bs == MIST_BATT_LOW) Serial.println("[BATTERY] Low - charge soon.");
-  }
 
   // Water/disc watchdog: probe every 60 s while running (during a brief
   // internal dip the user barely notices), or every 10 s while blocked.

--- a/extras/phone-app/.gitignore
+++ b/extras/phone-app/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+.dev.vars

--- a/extras/phone-app/README.md
+++ b/extras/phone-app/README.md
@@ -1,0 +1,155 @@
+# Mist Control — phone-sensor web app
+
+Drive the mist makers from a phone's **mic, light, motion, face, or music**, and
+choreograph several at once — all from one cute web page. Built for workshops.
+
+```
+   📱 phone (this web app, on HTTPS)              ☁ Cloudflare              🌫 mist makers
+   ┌───────────────────────────────┐        ┌──────────────────┐        ┌────────────────┐
+   │ reads its OWN sensors,         │  wss   │  Worker + Durable │  wss   │ XIAO ESP32-C6  │
+   │ turns them into a 0-100 level  │ ─────► │  Object = "room"  │ ─────► │ PhoneSensors   │
+   │ (mic/light/face/FFT/...)       │        │  passes messages  │        │ .ino (thin)    │
+   │ + shows every maker's status   │ ◄───── │  both directions  │ ◄───── │ reports status │
+   └───────────────────────────────┘        └──────────────────┘        └────────────────┘
+        does ALL the thinking                 free, no broker            just obeys + reports
+```
+
+**Why a cloud relay and not the board's own WiFi page?** Phone sensors (mic,
+camera, motion) only work on a *secure* (HTTPS) page. A board on its own WiFi
+serves plain HTTP, so iPhones flatly refuse sensor access there. Hosting this
+page on Cloudflare gives every phone secure sensor access with **no certificate
+warnings**. Mist reacts slowly (hundreds of ms), so cloud lag is invisible — and
+every maker just joins the same "room," so the phone keeps them in sync with no
+ESP-NOW channel fiddling.
+
+---
+
+## How the "room" works (it's just like MQTT)
+
+If you've used MQTT: a **broker** sits in the middle, phones **publish** messages,
+devices **subscribe**. This is the same idea, but the broker is a tiny
+**Cloudflare Worker** (a Durable Object) instead of a separate service you have to
+sign up for. Phones and makers open a WebSocket to the same room; the room
+forwards every phone message to the makers and every maker's status back to the
+phones. That's the whole thing — about 70 lines in `src/worker.js`.
+
+One Worker does **both** jobs: serves this web app **and** runs the room. So you
+deploy once and get one URL.
+
+---
+
+## Part A — deploy the relay + app to Cloudflare (one time, ~10 min)
+
+You need a free [Cloudflare account](https://dash.cloudflare.com/sign-up) and
+[Node.js](https://nodejs.org) installed.
+
+1. **Open a terminal in this folder** (`extras/phone-app`).
+
+2. **Log in to Cloudflare** (opens your browser once):
+   ```bash
+   npx wrangler login
+   ```
+
+3. **Deploy:**
+   ```bash
+   npx wrangler deploy
+   ```
+   Wrangler prints a URL like `https://mistmaker-relay.YOURNAME.workers.dev`.
+   **That URL is your app** — open it on your phone. Copy the host part
+   (`mistmaker-relay.YOURNAME.workers.dev`) for the firmware in Part B.
+
+   > Want a custom name? Edit `name = "..."` at the top of `wrangler.toml`.
+
+That's it — no database, no broker, no secrets. Updating the app later is just
+`npx wrangler deploy` again.
+
+### Will this stay free? Yes — comfortably.
+
+Cloudflare's free plan gives Durable Objects their **own 100,000 requests/day**,
+and incoming WebSocket messages are billed at **20:1** (20 messages = 1 request),
+so the real ceiling is **~2,000,000 messages/day**. Outgoing messages and serving
+this web page are **free and unlimited**. To stay frugal the app:
+
+- sends at most **8 messages/sec** per phone (mist can't react faster anyway), and
+- uses **send-on-change** — a steady level sends nothing.
+
+A 3-hour workshop with ~10 phones + ~6 makers uses a few percent of one day's
+free budget. And on the free plan you **cannot be charged** — at the (very
+distant) cap, the app just pauses until the daily reset (midnight UTC). The send
+rate lives in `SEND_HZ` at the top of `public/app.js` if you ever want to tune it.
+
+---
+
+## Part B — flash the makers (`examples/PhoneSensors`)
+
+Each mist maker runs the **same** sketch. Flash it once per board.
+
+1. In Arduino IDE, install the library **"WebSockets" by Markus Sattler**
+   (Library Manager) — plus MistMaker, as usual.
+2. Open `examples/PhoneSensors/PhoneSensors.ino`.
+3. Fill in the four lines near the top:
+   ```cpp
+   const char* WIFI_SSID  = "your-wifi";
+   const char* WIFI_PASS  = "your-password";
+   const char* RELAY_HOST = "mistmaker-relay.YOURNAME.workers.dev"; // from Part A
+   const char* ROOM       = "workshop";   // any phone in this room controls this maker
+   ```
+4. Select **XIAO_ESP32C6**, upload. Repeat for each board (no changes needed —
+   each names itself `Mist-XXXX` from its MAC address).
+
+> **Flash tip:** this sketch uses ~89% of the default flash partition. If you add
+> to it and it no longer fits, set **Tools → Partition Scheme → "Huge APP (3MB)"**.
+
+**Debugging a board:** open Serial Monitor at **115200**. Each board prints its
+name, WiFi + relay status, every mist level change, and a status line each second:
+```
+==============================
+  Mist-A4F1  (room: workshop)
+  relay: mistmaker-relay.YOURNAME.workers.dev
+==============================
+[WiFi] joining "your-wifi"... ok — ip 192.168.1.42, rssi -54 dBm
+[WS] connected — open the app on your phone to control me
+[CMD] mist level -> 30%
+[STAT] level=30%  current=148 mA  water=ok  wifi=relay-ok(-54 dBm)
+```
+The **same** status (level, current, water, signal) shows live in the app's
+**Your makers** panel — so you can watch a board from USB or from your phone.
+
+---
+
+## Using it at the workshop
+
+Open your Worker URL on a phone, then:
+
+- **Slide it** — the always-there manual slider (starts at a gentle 30%).
+- **Start misting** — master on/off. Pick *every maker* or one specific maker.
+- **Play with it** — tap a sense mode; it asks permission, then just works:
+  - **Mic** 🎤 — blow across the mic / make noise → more mist.
+  - **Light** 💡 — point the camera at a lamp, or cover it (toggle "cover = more").
+  - **Tilt** 📱 — lean the phone left/right.
+  - **Face** 😮 — open your mouth (or switch to brows / blink).
+  - **Music** 🎵 — play a song; the makers become a **spectrum** — one frequency
+    band each. Line them up for a vapor equalizer.
+- **Your makers** — with 2+ makers you get routing:
+  - **Together** — all in sync.
+  - **Wave** — a ripple/delay across them (use *spread*) — an animation.
+  - **Spectrum** — one audio band per maker (great with Music mode).
+
+### Sensor permission notes
+- **iPhone**: the first tap on Mic / Light / Face / Tilt shows a permission prompt
+  (camera, mic, or motion) — that's expected; tap allow. Motion needs that tap by
+  Apple's rules, which is why modes activate on tap.
+- Everything runs **on the phone** — no sensor data leaves the browser; only the
+  final mist level (a single number) goes to the makers.
+
+---
+
+## Files
+
+| File | What it is |
+|---|---|
+| `wrangler.toml` | Cloudflare config (the app + the room) |
+| `src/worker.js` | The Worker + Durable Object "room" (the relay) |
+| `public/index.html` · `app.css` · `app.js` | The phone web app (cute, vanilla, no build step) |
+
+Pairs with `examples/PhoneSensors/PhoneSensors.ino` (the firmware every maker runs).

--- a/extras/phone-app/README.md
+++ b/extras/phone-app/README.md
@@ -36,6 +36,11 @@ phones. That's the whole thing — about 70 lines in `src/worker.js`.
 One Worker does **both** jobs: serves this web app **and** runs the room. So you
 deploy once and get one URL.
 
+> **Access:** the room is open — anyone with your URL **and** the room name can
+> join and drive the makers. That's fine for a public workshop; for a private
+> session, change the room name (top-right ☁ chip) to something non-obvious. No
+> data is stored and nothing is logged — the Worker only passes messages through.
+
 ---
 
 ## Part A — deploy the relay + app to Cloudflare (one time, ~10 min)

--- a/extras/phone-app/package.json
+++ b/extras/phone-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mistmaker-relay",
+  "private": true,
+  "description": "Cloudflare Worker relay + phone web app for the Programmable Mist Maker",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4"
+  }
+}

--- a/extras/phone-app/public/app.css
+++ b/extras/phone-app/public/app.css
@@ -20,6 +20,9 @@
 }
 
 * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+/* keep the HTML `hidden` attribute authoritative over the display rules below
+   (a class's `display` otherwise overrides the default [hidden]{display:none}) */
+[hidden] { display: none !important; }
 
 html { background: var(--f5); }
 
@@ -67,6 +70,15 @@ body {
   padding: 18px 4px 14px;
   position: sticky; top: 0; z-index: 5;
 }
+/* subtle frosted scrim so cards stay readable as they scroll under the header;
+   masked to fade out downward — no hard edge, header content stays crisp above */
+.bar::before {
+  content: ""; position: absolute; inset: -2px -16px -20px; z-index: -1; pointer-events: none;
+  backdrop-filter: blur(7px); -webkit-backdrop-filter: blur(7px);
+  background: linear-gradient(180deg, rgb(123 205 232 / .42), rgb(123 205 232 / 0));
+  -webkit-mask-image: linear-gradient(180deg, #000 52%, transparent 100%);
+          mask-image: linear-gradient(180deg, #000 52%, transparent 100%);
+}
 .mark {
   font-family: var(--font-display); font-size: 1.25rem; color: var(--mist);
   display: flex; align-items: center; gap: 7px; margin-right: auto;
@@ -106,10 +118,10 @@ h2 { font-family: var(--font-display); font-weight: 400; font-size: 1.35rem; mar
 
 /* ── hero ────────────────────────────────────────────────────────────── */
 .hero { text-align: center; padding-top: 18px; }
-.level { font-family: var(--font-display); color: var(--ink); line-height: .9; margin: 4px 0 2px; }
+.level { font-family: var(--font-display); color: var(--ink); line-height: 1; margin: 4px 0 16px; }
 .level b { font-size: 5.4rem; font-weight: 400; }
-.level span { font-size: 2rem; opacity: .55; }
-.puffs { display: flex; justify-content: center; gap: 8px; height: 16px; margin-bottom: 14px; }
+.level span { font-size: 2rem; opacity: .55; margin-left: 2px; }
+.puffs { display: flex; justify-content: center; gap: 9px; height: 14px; margin: 0 0 18px; }
 .puffs i {
   width: 12px; height: 12px; border-radius: 50%;
   background: var(--f4); opacity: .25; transition: opacity .25s, transform .25s;

--- a/extras/phone-app/public/app.css
+++ b/extras/phone-app/public/app.css
@@ -1,0 +1,227 @@
+/* Mist Control — cute sky-blue skin, mirroring shop.byproductlab.com
+   (poster palette: mist white + sunny yellow + teal ink; Young Serif / Inter /
+   Knewave). Mobile-first, big touch targets, clean and readable. */
+
+:root {
+  --mist:    #edfaff;
+  --accent:  #ffc831;
+  --f2: #8edcee; --f3: #6fcfe8; --f4: #58c4e0; --f5: #3fb5d8;
+  --f6: #2d9fc4; --f7: #2596be; --f8: #1d81a6; --f9: #16718f;
+  --ink:     #0c4a61;
+  --ink-soft:#3a6b7e;
+
+  --font-display: 'Young Serif', ui-serif, Georgia, serif;
+  --font-body:    'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-hand:    'Knewave', cursive;
+
+  --card-radius: 22px;
+  --card-shadow: 0 14px 34px rgb(12 74 97 / .26), 0 2px 8px rgb(12 74 97 / .16);
+  --live: 0;            /* 0..1 live mist level, set by JS for ambient effects */
+}
+
+* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+
+html { background: var(--f5); }
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--ink);
+  min-height: 100dvh;
+  padding: 0 16px calc(28px + env(safe-area-inset-bottom));
+  max-width: 480px; margin-inline: auto;
+}
+
+::selection { background: var(--accent); color: var(--ink); }
+:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; border-radius: 8px; }
+
+/* ── dreamy sky + clouds + grain ─────────────────────────────────────── */
+.sky {
+  position: fixed; inset: 0; z-index: -3;
+  background: linear-gradient(180deg, var(--f2) 0%, var(--f4) 42%, var(--f7) 100%);
+}
+.clouds { position: fixed; inset: 0; z-index: -2; overflow: hidden; pointer-events: none; }
+.clouds span {
+  position: absolute; display: block;
+  width: 220px; height: 70px; border-radius: 100px;
+  background: radial-gradient(closest-side, rgb(237 250 255 / .9), rgb(237 250 255 / 0));
+  filter: blur(6px);
+  opacity: calc(.35 + var(--live) * .45);             /* puff up as mist rises */
+  animation: drift 38s linear infinite;
+  transition: opacity .8s ease;
+}
+.clouds span:nth-child(1){ top: 12%; left: -30%; transform: scale(1.3); animation-duration: 46s; }
+.clouds span:nth-child(2){ top: 38%; left: -50%; transform: scale(.9);  animation-duration: 60s; animation-delay: -20s; }
+.clouds span:nth-child(3){ top: 68%; left: -40%; transform: scale(1.6); animation-duration: 52s; animation-delay: -8s; }
+@keyframes drift { to { left: 130%; } }
+
+.grain {
+  position: fixed; inset: 0; z-index: -1; pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='220' height='220'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 220px 220px; mix-blend-mode: screen; opacity: .12;
+}
+
+/* ── header ──────────────────────────────────────────────────────────── */
+.bar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 18px 4px 14px;
+  position: sticky; top: 0; z-index: 5;
+}
+.mark {
+  font-family: var(--font-display); font-size: 1.25rem; color: var(--mist);
+  display: flex; align-items: center; gap: 7px; margin-right: auto;
+  text-shadow: 0 1px 12px rgb(12 74 97 / .45);
+}
+.cloud-ico { width: 26px; height: 26px; fill: none; stroke: var(--mist); stroke-width: 1.6; }
+.chip {
+  font: 600 .8rem var(--font-body); color: var(--ink);
+  background: var(--mist); border: 0; border-radius: 999px;
+  padding: 7px 12px; box-shadow: 0 3px 10px rgb(12 74 97 / .2);
+}
+.chip b { font-weight: 700; }
+.conn { display: flex; align-items: center; gap: 6px; font-size: .72rem; color: var(--mist); font-weight: 600; }
+.conn i { width: 9px; height: 9px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 3px rgb(255 200 49 / .3); }
+.conn.ok i  { background: #5ad08a; box-shadow: 0 0 0 3px rgb(90 208 138 / .3); }
+.conn.off i { background: #ff8f8f; box-shadow: 0 0 0 3px rgb(255 143 143 / .3); }
+
+/* ── cards ───────────────────────────────────────────────────────────── */
+.card {
+  background: rgb(237 250 255 / .94);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  padding: 22px;
+  margin-bottom: 16px;
+  animation: drift-up .6s cubic-bezier(.22,1,.36,1) both;
+}
+.card:nth-child(2){ animation-delay: .05s; }
+.card:nth-child(3){ animation-delay: .1s; }
+.card:nth-child(4){ animation-delay: .15s; }
+@keyframes drift-up { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+
+.phead { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 14px; }
+h2 { font-family: var(--font-display); font-weight: 400; font-size: 1.35rem; margin: 0; color: var(--ink); }
+.pval { font-size: .9rem; color: var(--ink-soft); font-weight: 600; }
+.pval b { color: var(--ink); font-size: 1.05rem; }
+.eyebrow { font-family: var(--font-hand); color: var(--f8); font-size: 1rem; letter-spacing: .02em; text-align: center; }
+
+/* ── hero ────────────────────────────────────────────────────────────── */
+.hero { text-align: center; padding-top: 18px; }
+.level { font-family: var(--font-display); color: var(--ink); line-height: .9; margin: 4px 0 2px; }
+.level b { font-size: 5.4rem; font-weight: 400; }
+.level span { font-size: 2rem; opacity: .55; }
+.puffs { display: flex; justify-content: center; gap: 8px; height: 16px; margin-bottom: 14px; }
+.puffs i {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--f4); opacity: .25; transition: opacity .25s, transform .25s;
+}
+.targetline { font-size: .92rem; color: var(--ink-soft); margin-bottom: 16px; }
+.sel {
+  font: 600 .92rem var(--font-body); color: var(--ink);
+  background: #fff; border: 2px solid var(--f3); border-radius: 12px;
+  padding: 7px 10px; max-width: 60%;
+}
+
+/* ── buttons ─────────────────────────────────────────────────────────── */
+.btn {
+  font: 700 1rem var(--font-body); color: var(--ink);
+  background: var(--accent); border: 0; border-radius: 16px;
+  padding: 15px 20px; width: 100%;
+  box-shadow: 0 6px 0 #d99e10, 0 10px 20px rgb(12 74 97 / .2);
+  transition: transform .08s, box-shadow .08s;
+}
+.btn:active { transform: translateY(4px); box-shadow: 0 2px 0 #d99e10, 0 4px 10px rgb(12 74 97 / .2); }
+.btn.big { font-size: 1.15rem; padding: 17px; }
+.btn.on  { background: var(--ink); color: var(--mist); box-shadow: 0 6px 0 #073544, 0 10px 20px rgb(12 74 97 / .25); }
+.btn.on:active { box-shadow: 0 2px 0 #073544, 0 4px 10px rgb(12 74 97 / .2); }
+.btn.ghost { background: transparent; color: var(--ink); box-shadow: inset 0 0 0 2px var(--f3); }
+.btn.ghost:active { transform: translateY(2px); }
+.hint { font-size: .82rem; color: var(--ink-soft); margin-top: 12px; line-height: 1.4; }
+
+/* ── sliders ─────────────────────────────────────────────────────────── */
+.slider { -webkit-appearance: none; appearance: none; width: 100%; height: 14px; border-radius: 999px;
+  background: linear-gradient(90deg, var(--f6) 0%, var(--f6) var(--fill,30%), var(--f2) var(--fill,30%));
+  outline: none; }
+.slider.thin { height: 10px; }
+.slider::-webkit-slider-thumb { -webkit-appearance: none; width: 30px; height: 30px; border-radius: 50%;
+  background: var(--accent); border: 4px solid #fff; box-shadow: 0 3px 10px rgb(12 74 97 / .35); cursor: pointer; }
+.slider::-moz-range-thumb { width: 26px; height: 26px; border-radius: 50%; background: var(--accent);
+  border: 4px solid #fff; box-shadow: 0 3px 10px rgb(12 74 97 / .35); cursor: pointer; }
+.ticks { display: flex; justify-content: space-between; font-size: .72rem; color: var(--ink-soft); margin-top: 8px; }
+
+/* ── sense modes ─────────────────────────────────────────────────────── */
+.pill { font: 700 .72rem var(--font-body); text-transform: lowercase; color: var(--ink);
+  background: var(--accent); border-radius: 999px; padding: 4px 11px; }
+.modes { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
+.mode {
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  background: #fff; border: 2px solid transparent; border-radius: 15px;
+  padding: 11px 4px 9px; color: var(--ink);
+  box-shadow: 0 3px 9px rgb(12 74 97 / .12); transition: transform .1s, border-color .15s, background .15s;
+}
+.mode svg { width: 22px; height: 22px; fill: none; stroke: var(--f8); stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+.mode b { font-size: .76rem; font-weight: 700; }
+.mode small { font-size: .58rem; color: var(--ink-soft); text-align: center; line-height: 1.1; }
+.mode:active { transform: scale(.94); }
+.mode.on { background: var(--accent); border-color: var(--ink); }
+.mode.on svg { stroke: var(--ink); }
+.mode.on small { color: var(--ink); }
+
+.sensor { margin-top: 16px; }
+.meter { position: relative; height: 46px; border-radius: 13px; background: var(--f2); overflow: hidden;
+  box-shadow: inset 0 2px 6px rgb(12 74 97 / .15); }
+.meter i { position: absolute; inset: 0; width: var(--fill, 0%); background: linear-gradient(90deg, var(--f5), var(--accent));
+  transition: width .12s linear; }
+.meter b { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  font-weight: 700; font-size: 1rem; color: var(--ink); }
+#cam { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+.bands { width: 100%; height: 70px; border-radius: 13px; background: var(--f2); margin-top: 10px;
+  box-shadow: inset 0 2px 6px rgb(12 74 97 / .15); display: block; }
+
+.srow { display: flex; align-items: center; gap: 12px; margin-top: 14px; }
+.srow label { font-size: .82rem; color: var(--ink-soft); font-weight: 600; min-width: 74px; }
+.toggle { width: 50px; height: 28px; border-radius: 999px; border: 0; background: var(--f3); position: relative; transition: background .15s; }
+.toggle::after { content: ""; position: absolute; top: 3px; left: 3px; width: 22px; height: 22px; border-radius: 50%; background: #fff; transition: transform .15s; box-shadow: 0 1px 4px rgb(12 74 97 / .3); }
+.toggle[aria-checked="true"] { background: var(--accent); }
+.toggle[aria-checked="true"]::after { transform: translateX(22px); }
+
+/* ── makers ──────────────────────────────────────────────────────────── */
+.route { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 14px; }
+.rbtn { display: flex; flex-direction: column; gap: 2px; align-items: center; background: #fff; border: 2px solid transparent;
+  border-radius: 14px; padding: 10px 4px; color: var(--ink); font-weight: 700; font-size: .82rem;
+  box-shadow: 0 3px 9px rgb(12 74 97 / .12); transition: border-color .15s, background .15s; }
+.rbtn small { font-size: .58rem; font-weight: 500; color: var(--ink-soft); }
+.rbtn.on { background: var(--accent); border-color: var(--ink); }
+.rbtn.on small { color: var(--ink); }
+
+.devs { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.devs .empty { color: var(--ink-soft); font-size: .88rem; text-align: center; padding: 14px 0; }
+.dev { background: #fff; border-radius: 14px; padding: 12px 14px; box-shadow: 0 3px 9px rgb(12 74 97 / .1); }
+.dev-top { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.dev-name { font-weight: 700; font-size: .92rem; }
+.dev-sig { margin-left: auto; font-size: .68rem; color: var(--ink-soft); display: flex; align-items: center; gap: 4px; }
+.dev-bar { height: 10px; border-radius: 999px; background: var(--f2); overflow: hidden; }
+.dev-bar i { display: block; height: 100%; width: 0%; background: linear-gradient(90deg, var(--f5), var(--accent)); transition: width .3s; }
+.dev-meta { display: flex; gap: 10px; font-size: .72rem; color: var(--ink-soft); margin-top: 7px; }
+.badge { padding: 1px 7px; border-radius: 999px; font-weight: 700; font-size: .66rem; }
+.badge.ok  { background: rgb(90 208 138 / .22); color: #1f7a4d; }
+.badge.warn{ background: rgb(255 200 49 / .3); color: #8a6200; }
+.badge.bad { background: rgb(255 143 143 / .28); color: #a23b3b; }
+
+/* ── footer ──────────────────────────────────────────────────────────── */
+.foot { display: flex; justify-content: space-between; align-items: center; color: var(--mist);
+  font-size: .72rem; padding: 6px 4px 4px; opacity: .85; }
+.foot .sig { font-family: var(--font-hand); font-size: .95rem; letter-spacing: .03em; }
+
+/* ── dialog ──────────────────────────────────────────────────────────── */
+.dlg { border: 0; border-radius: 20px; padding: 24px; max-width: 340px; width: 90%;
+  background: var(--mist); color: var(--ink); box-shadow: var(--card-shadow); }
+.dlg::backdrop { background: rgb(12 74 97 / .4); backdrop-filter: blur(2px); }
+.dlg h3 { font-family: var(--font-display); font-weight: 400; margin: 0 0 8px; font-size: 1.3rem; }
+.dlg p { font-size: .82rem; color: var(--ink-soft); line-height: 1.45; margin: 0 0 14px; }
+.text { width: 100%; font: 600 1rem var(--font-body); color: var(--ink); border: 2px solid var(--f3);
+  border-radius: 12px; padding: 11px; background: #fff; }
+.dlg menu { display: flex; gap: 10px; padding: 0; margin: 16px 0 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .card, .clouds span { animation: none; }
+}

--- a/extras/phone-app/public/app.js
+++ b/extras/phone-app/public/app.js
@@ -303,8 +303,8 @@ function drawBands(cx, arr) {
 // ───────────────────────── mode switching ─────────────────────────
 async function selectMode(key) {
   const next = SOURCES[key];
-  if (source === next) return setManual();          // tapping the active mode → back to slider
-  const myGen = ++modeGen;                            // cancel-token: the newest tap wins
+  const myGen = ++modeGen;                            // cancel-token first: also cancels an in-flight
+  if (source === next) return setManual();           // start() when toggling the active mode back off
   if (key === "mic" || key === "audio") getAudioCtx(); // unlock audio inside this tap (iOS)
   if (source) source.stop();
   source = next;                                      // tick reads it; each read() self-guards until ready
@@ -322,8 +322,11 @@ async function selectMode(key) {
     running = true; setEngage();                      // auto-start so it "just works"
   } catch (err) {
     if (myGen !== modeGen) return;                     // superseded; the newer call owns the UI
-    sensorHint.textContent = "⚠ " + (err.message || "Couldn't start that sensor.");
-    setManual();
+    source = null; energy = +manual.value;             // fall back to the slider, but…
+    [...modesEl.children].forEach(b => b.classList.remove("on"));
+    modePill.textContent = "slider";
+    sensorEl.hidden = false;                            // …keep the panel up to SHOW why it failed
+    sensorHint.textContent = "⚠ " + (err.message || "Couldn't start that sensor — check the permission prompt.");
   }
 }
 function setManual() {

--- a/extras/phone-app/public/app.js
+++ b/extras/phone-app/public/app.js
@@ -1,0 +1,370 @@
+/* Mist Control — phone web app.
+   The phone does all the thinking: it reads its own sensors, turns each into a
+   0-100 mist level, and sends compact commands to the mist makers through the
+   Cloudflare relay. Makers just obey + report status back.
+
+   Staying on Cloudflare's free tier: we cap sends at SEND_HZ and only transmit
+   when a value actually changes (send-on-change). A steady hand sends nothing. */
+
+// ───────────────────────── config ─────────────────────────
+const SEND_HZ      = 8;     // max commands/sec to the relay (mist reacts slower than this anyway)
+const DELTA        = 2;     // only send if a level moved at least this many %
+const KEEPALIVE_MS = 2000;  // …but re-send unchanged values this often so a maker can't drift
+const MIN_INTERVAL = 1000 / SEND_HZ;
+const MODEL_URL = "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task";
+const VISION_CDN = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.20";
+
+// ───────────────────────── state ─────────────────────────
+let ws, room, running = false;
+let source = null;          // active input: null (manual) or a sensor object
+let energy = 0;             // current 0-100 from the active source
+let bands = null;           // audio mode: per-band 0-100 array
+let route = "sync";         // sync | phase | spectrum
+const makers = [];          // [{id,name,level,current_ma,water,rssi,seen}]
+const seen = new Map();     // send-on-change memory: key -> last value sent
+let lastSendAt = 0, lastKeepAlive = 0, waveT = 0;
+
+// ───────────────────────── dom ─────────────────────────
+const $ = (id) => document.getElementById(id);
+const connEl=$("conn"), connTxt=$("connTxt"), roomName=$("roomName");
+const levelBig=$("levelBig"), targetSel=$("target"), engage=$("engage"), hint=$("hint");
+const manual=$("manual"), manualVal=$("manualVal");
+const modesEl=$("modes"), modePill=$("modePill"), sensorEl=$("sensor");
+const meterFill=$("meterFill"), meterTxt=$("meterTxt"), cam=$("cam"), bandsCv=$("bands");
+const gain=$("gain"), invertRow=$("invertRow"), invertBtn=$("invert"), invLbl=$("invLbl"), sensorHint=$("sensorHint");
+const routeEl=$("route"), phaseCtl=$("phaseCtl"), spread=$("spread");
+const devsEl=$("devs"), devCount=$("devCount"), puffs=$("puffs");
+
+// ───────────────────────── connection ─────────────────────────
+function connect() {
+  room = new URL(location).searchParams.get("room")
+       || localStorage.getItem("mm_room") || "workshop";
+  roomName.textContent = room;
+  const url = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws?room=${encodeURIComponent(room)}&role=phone&name=Phone`;
+  setConn("…", "saying hi…");
+  ws = new WebSocket(url);
+  ws.onopen    = () => setConn("ok", "connected");
+  ws.onclose   = () => { setConn("off", "reconnecting…"); setTimeout(connect, 2000); };
+  ws.onerror   = () => ws.close();
+  ws.onmessage = (e) => onMessage(e.data);
+}
+function setConn(cls, txt) { connEl.className = "conn " + cls; connTxt.textContent = txt; }
+
+function onMessage(raw) {
+  let m; try { m = JSON.parse(raw); } catch { return; }
+  if (m.t === "roster")      setRoster(m.devices || []);
+  else if (m.t === "status") updateMaker(m);
+}
+
+// ───────────────────────── send layer (throttle + on-change) ─────────────────────────
+function wsSend(obj) { if (ws && ws.readyState === 1) ws.send(JSON.stringify(obj)); }
+
+// returns true and remembers it if `val` for `key` is worth sending
+function isNew(key, val) {
+  const p = seen.get(key);
+  return p === undefined || Math.abs(p - val) >= DELTA;
+}
+
+function dispatch() {
+  const now = performance.now();
+  if (now - lastSendAt < MIN_INTERVAL) return;
+  const force = now - lastKeepAlive > KEEPALIVE_MS;   // periodic anti-drift resend
+
+  if (route === "sync" || makers.length < 2) {
+    const lvl = Math.round(energy), tgt = targetSel.value;
+    const key = "s:" + tgt;
+    if (force || isNew(key, lvl)) { wsSend({ t: "set", target: tgt, level: lvl }); seen.set(key, lvl); lastSendAt = now; }
+  } else {
+    const levels = {};
+    if (route === "spectrum" && bands) {
+      makers.forEach((d, i) => levels[d.id] = Math.round(bands[i % bands.length] || 0));
+    } else { // phase: a traveling wave scaled by the input energy
+      const sp = (spread.value / 100) * Math.PI;
+      makers.forEach((d, i) => levels[d.id] = Math.round(energy * (0.5 + 0.5 * Math.sin(waveT - i * sp))));
+    }
+    let any = force;
+    for (const id in levels) if (isNew("m:" + id, levels[id])) any = true;
+    if (any) { wsSend({ t: "multi", levels }); for (const id in levels) seen.set("m:" + id, levels[id]); lastSendAt = now; }
+  }
+  if (force) lastKeepAlive = now;
+}
+
+function stopAll() { wsSend({ t: "set", target: "all", level: 0 }); seen.clear(); }
+
+// ───────────────────────── makers (roster + live status) ─────────────────────────
+function setRoster(list) {
+  // keep known live status, add/remove to match the roster
+  const ids = new Set(list.map(d => d.id));
+  for (let i = makers.length - 1; i >= 0; i--) if (!ids.has(makers[i].id)) makers.splice(i, 1);
+  for (const d of list) if (!makers.find(m => m.id === d.id)) makers.push({ ...d, level: 0, current_ma: 0, water: "?", rssi: 0 });
+  renderTargets(); renderDevs(); routeEl.hidden = makers.length < 2;
+}
+function updateMaker(m) {
+  const d = makers.find(x => x.id === m.id);
+  if (!d) return;
+  Object.assign(d, m); d.seen = performance.now();
+  renderDevs();
+}
+// Devices announce their own name/water, and anyone can join the room as a
+// "device" — so treat those strings as untrusted and escape before innerHTML.
+const esc = (s) => String(s).replace(/[&<>"']/g, c => (
+  { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+function renderTargets() {
+  const cur = targetSel.value;
+  targetSel.innerHTML = '<option value="all">every maker</option>'
+    + makers.map(d => `<option value="${esc(d.id)}">${esc(d.name)}</option>`).join("");
+  if ([...targetSel.options].some(o => o.value === cur)) targetSel.value = cur;
+}
+function renderDevs() {
+  devCount.textContent = makers.length;
+  if (!makers.length) { devsEl.innerHTML = '<li class="empty">No makers yet — flash one &amp; power it on ☁</li>'; return; }
+  devsEl.innerHTML = makers.map(d => {
+    const lvl = clamp(+d.level || 0);
+    const w = d.water === "ok" ? '<span class="badge ok">water ok</span>'
+            : d.water === "low" ? '<span class="badge warn">water low</span>'
+            : d.water === "?" ? "" : `<span class="badge bad">${esc(d.water)}</span>`;
+    const sig = Number.isFinite(+d.rssi) && d.rssi ? `${(+d.rssi).toFixed(0)} dBm` : "";
+    return `<li class="dev"><div class="dev-top"><span class="dev-name">${esc(d.name)}</span>
+      <span class="dev-sig">📶 ${esc(sig)}</span></div>
+      <div class="dev-bar"><i style="width:${lvl}%"></i></div>
+      <div class="dev-meta"><span>${lvl}%</span><span>${Math.round(+d.current_ma || 0)} mA</span>${w}</div></li>`;
+  }).join("");
+}
+
+// ───────────────────────── input sources ─────────────────────────
+// Each source sets `energy` (0-100) and optionally `bands`. read() runs per frame.
+const G = () => gain.value / 50;               // sensitivity 0.02..2, 1 = neutral
+let inverted = false;
+
+const Manual = {
+  name: "slider",
+  start() { energy = +manual.value; },
+  read() {},
+  stop() {},
+};
+
+function micAnalyser(fftSize) {
+  return navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    ctx.resume();
+    const an = ctx.createAnalyser(); an.fftSize = fftSize;
+    ctx.createMediaStreamSource(stream).connect(an);
+    return { ctx, an, stream };
+  });
+}
+
+const Mic = {
+  name: "mic", hint: "Blow across the mic or make noise — louder = more mist.",
+  async start() { this.a = await micAnalyser(1024); this.buf = new Uint8Array(this.a.an.fftSize); },
+  read() {
+    if (!this.a) return;
+    this.a.an.getByteTimeDomainData(this.buf);
+    let s = 0; for (const v of this.buf) { const x = (v - 128) / 128; s += x * x; }
+    const rms = Math.sqrt(s / this.buf.length);          // 0..~1
+    energy = clamp(rms * 320 * G());
+  },
+  stop() { teardown(this.a); this.a = null; },
+};
+
+const Light = {
+  name: "light", invert: true, invLabel: "cover = more",
+  hint: "Point the camera at a lamp, or cover it with your hand.",
+  async start() {
+    this.stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: "environment" } });
+    cam.srcObject = this.stream; await cam.play();
+    this.cv = document.createElement("canvas"); this.cv.width = this.cv.height = 24;
+    this.cx = this.cv.getContext("2d", { willReadFrequently: true });
+  },
+  read() {
+    if (!this.cx || cam.readyState < 2) return;
+    this.cx.drawImage(cam, 0, 0, 24, 24);
+    const px = this.cx.getImageData(0, 0, 24, 24).data;
+    let lum = 0; for (let i = 0; i < px.length; i += 4) lum += 0.299*px[i] + 0.587*px[i+1] + 0.114*px[i+2];
+    let b = clamp((lum / (px.length / 4)) / 255 * 100 * G());
+    energy = inverted ? 100 - b : b;
+  },
+  stop() { teardown({ stream: this.stream }); this.stream = null; },
+};
+
+const Motion = {
+  name: "motion", invert: true, invLabel: "flip direction",
+  hint: "Tilt the phone left/right. Flat = off, tilted = full.",
+  async start() {
+    if (typeof DeviceOrientationEvent !== "undefined" && DeviceOrientationEvent.requestPermission) {
+      const r = await DeviceOrientationEvent.requestPermission();   // iOS: needs this tap
+      if (r !== "granted") throw new Error("Motion access was denied.");
+    }
+    this.h = (e) => { this.g = e.gamma || 0; };                     // -90..90 left/right tilt
+    window.addEventListener("deviceorientation", this.h);
+  },
+  read() {
+    let v = clamp(Math.abs(this.g || 0) / 60 * 100 * G());
+    energy = inverted ? 100 - v : v;
+  },
+  stop() { if (this.h) window.removeEventListener("deviceorientation", this.h); },
+};
+
+const Face = {
+  name: "face", hint: "Open your mouth wide. (Tap ▸ for brows or blink.)",
+  expr: "mouth",
+  async start() {
+    sensorHint.textContent = "loading face tracking…";
+    const vision = await import(VISION_CDN);
+    const fileset = await vision.FilesetResolver.forVisionTasks(VISION_CDN + "/wasm");
+    this.fl = await vision.FaceLandmarker.createFromOptions(fileset, {
+      baseOptions: { modelAssetPath: MODEL_URL },
+      outputFaceBlendshapes: true, runningMode: "VIDEO", numFaces: 1,
+    });
+    this.stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: "user" } });
+    cam.srcObject = this.stream; await cam.play();
+    this.addExprPicker();
+    sensorHint.textContent = this.hint;
+  },
+  read() {
+    if (!this.fl || cam.readyState < 2) return;
+    const res = this.fl.detectForVideo(cam, performance.now());
+    const cat = res.faceBlendshapes?.[0]?.categories;
+    if (!cat) { energy = 0; return; }
+    const get = (n) => cat.find(c => c.categoryName === n)?.score || 0;
+    let v = this.expr === "mouth" ? get("jawOpen")
+          : this.expr === "brows" ? (get("browOuterUpLeft") + get("browOuterUpRight") + get("browInnerUp")) / 3
+          : (get("eyeBlinkLeft") + get("eyeBlinkRight")) / 2;       // blink
+    energy = clamp(v * 130 * G());
+  },
+  addExprPicker() {
+    if (this.picker) return;
+    this.picker = document.createElement("div"); this.picker.className = "route"; this.picker.style.marginTop = "12px";
+    [["mouth","😮 Mouth"],["brows","🤨 Brows"],["blink","😉 Blink"]].forEach(([k, label], i) => {
+      const b = document.createElement("button"); b.className = "rbtn" + (i === 0 ? " on" : ""); b.textContent = label;
+      b.onclick = () => { this.expr = k; [...this.picker.children].forEach(c => c.classList.remove("on")); b.classList.add("on"); };
+      this.picker.appendChild(b);
+    });
+    sensorHint.before(this.picker);
+  },
+  stop() { teardown({ stream: this.stream }); this.fl?.close?.(); this.fl = null; this.picker?.remove(); this.picker = null; },
+};
+
+const Audio = {
+  name: "audio", hint: "Play music near the phone — each maker becomes one frequency band.",
+  async start() {
+    this.a = await micAnalyser(256); this.buf = new Uint8Array(this.a.an.frequencyBinCount);
+    bandsCv.hidden = false; this.ctx2d = bandsCv.getContext("2d");
+    bandsCv.width = bandsCv.clientWidth * devicePixelRatio; bandsCv.height = 70 * devicePixelRatio;
+    if (makers.length >= 2) setRoute("spectrum");
+  },
+  read() {
+    if (!this.a) return;
+    this.a.an.getByteFrequencyData(this.buf);
+    const N = Math.max(1, Math.min(makers.length || 8, 16));
+    const out = new Array(N).fill(0);
+    const lo = 2, hi = this.buf.length;                  // skip DC bin
+    for (let i = 0; i < N; i++) {
+      const a = lo + Math.floor((hi - lo) * i / N), b = lo + Math.floor((hi - lo) * (i + 1) / N);
+      let s = 0; for (let j = a; j < b; j++) s += this.buf[j];
+      out[i] = clamp((s / Math.max(1, b - a)) / 255 * 140 * G());
+    }
+    bands = out;
+    energy = out.reduce((p, c) => p + c, 0) / N;
+    drawBands(this.ctx2d, out);
+  },
+  stop() { teardown(this.a); this.a = null; bands = null; bandsCv.hidden = true; },
+};
+
+const SOURCES = { mic: Mic, light: Light, motion: Motion, face: Face, audio: Audio };
+
+function teardown(a) { try { a?.stream?.getTracks().forEach(t => t.stop()); a?.ctx?.close?.(); } catch {} }
+function clamp(v) { return v < 0 ? 0 : v > 100 ? 100 : v; }
+
+function drawBands(cx, arr) {
+  const W = bandsCv.width, H = bandsCv.height, n = arr.length, bw = W / n;
+  cx.clearRect(0, 0, W, H);
+  arr.forEach((v, i) => {
+    const h = (v / 100) * H;
+    cx.fillStyle = i % 2 ? "#2596be" : "#ffc831";
+    cx.fillRect(i * bw + 2, H - h, bw - 4, h);
+  });
+}
+
+// ───────────────────────── mode switching ─────────────────────────
+async function selectMode(key) {
+  const next = SOURCES[key];
+  if (source === next) return setManual();          // tapping the active mode → back to slider
+  if (source) source.stop();
+  // reset per-mode UI
+  invertRow.hidden = true; bandsCv.hidden = true; sensorHint.textContent = "";
+  inverted = false; invertBtn.setAttribute("aria-checked", "false");
+  try {
+    source = next; sensorEl.hidden = false;
+    [...modesEl.children].forEach(b => b.classList.toggle("on", b.dataset.mode === key));
+    modePill.textContent = next.name;
+    if (next.invert) { invertRow.hidden = false; invLbl.textContent = next.invLabel || "invert"; }
+    await next.start();
+    sensorHint.textContent = next.hint || "";
+    running = true; setEngage();                     // auto-start so it "just works"
+  } catch (err) {
+    sensorHint.textContent = "⚠ " + (err.message || "Couldn't start that sensor.");
+    setManual();
+  }
+}
+function setManual() {
+  if (source) source.stop();
+  source = null; sensorEl.hidden = true;
+  [...modesEl.children].forEach(b => b.classList.remove("on"));
+  modePill.textContent = "slider"; energy = +manual.value;
+}
+
+// ───────────────────────── ui wiring ─────────────────────────
+manual.oninput = () => { manualVal.textContent = manual.value + "%"; setFill(manual); if (!source) energy = +manual.value; };
+gain.oninput   = () => setFill(gain);
+spread.oninput = () => setFill(spread);
+invertBtn.onclick = () => { inverted = !inverted; invertBtn.setAttribute("aria-checked", inverted); };
+modesEl.onclick = (e) => { const b = e.target.closest(".mode"); if (b) selectMode(b.dataset.mode); };
+
+engage.onclick = () => { running = !running; if (!running) stopAll(); setEngage(); };
+function setEngage() {
+  engage.textContent = running ? "Stop misting" : "Start misting";
+  engage.classList.toggle("on", running);
+}
+
+routeEl.onclick = (e) => { const b = e.target.closest(".rbtn"); if (b) setRoute(b.dataset.route); };
+function setRoute(r) {
+  route = r;
+  [...routeEl.children].forEach(b => b.classList.toggle("on", b.dataset.route === r));
+  phaseCtl.hidden = r !== "phase"; seen.clear();
+}
+
+// room dialog
+$("roomBtn").onclick = () => { $("roomInput").value = room; $("roomDlg").showModal(); };
+$("roomSave").onclick = (e) => {
+  const v = $("roomInput").value.trim(); if (!v) return;
+  localStorage.setItem("mm_room", v);
+  const u = new URL(location); u.searchParams.set("room", v); history.replaceState(0, "", u);
+  if (ws) ws.close(); connect();
+};
+
+function setFill(el) { el.style.setProperty("--fill", ((el.value - el.min) / (el.max - el.min) * 100) + "%"); }
+
+// ───────────────────────── main loop ─────────────────────────
+function tick(now) {
+  if (source && source.read) source.read();
+  waveT += 0.06;
+  const lvl = Math.round(energy);
+  levelBig.textContent = lvl;
+  meterFill.style.setProperty("--fill", lvl + "%"); meterTxt.textContent = lvl + "%";
+  document.documentElement.style.setProperty("--live", (lvl / 100).toFixed(2));
+  [...puffs.children].forEach((p, i) => {
+    const on = lvl > i * 20;
+    p.style.opacity = on ? 0.85 : 0.2;
+    p.style.transform = on ? "translateY(-4px) scale(1.15)" : "none";
+  });
+  if (running) dispatch();
+  requestAnimationFrame(tick);
+}
+
+// ───────────────────────── boot ─────────────────────────
+setFill(manual); setFill(gain); setFill(spread);
+manualVal.textContent = manual.value + "%";
+energy = +manual.value;          // start matching the slider (default 30%)
+connect();
+requestAnimationFrame(tick);

--- a/extras/phone-app/public/app.js
+++ b/extras/phone-app/public/app.js
@@ -15,7 +15,7 @@ const MODEL_URL = "https://storage.googleapis.com/mediapipe-models/face_landmark
 const VISION_CDN = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.20";
 
 // ───────────────────────── state ─────────────────────────
-let ws, room, running = false;
+let ws, room, running = false, reconnectTimer = 0, modeGen = 0, audioCtx = null;
 let source = null;          // active input: null (manual) or a sensor object
 let energy = 0;             // current 0-100 from the active source
 let bands = null;           // audio mode: per-band 0-100 array
@@ -27,7 +27,7 @@ let lastSendAt = 0, lastKeepAlive = 0, waveT = 0;
 // ───────────────────────── dom ─────────────────────────
 const $ = (id) => document.getElementById(id);
 const connEl=$("conn"), connTxt=$("connTxt"), roomName=$("roomName");
-const levelBig=$("levelBig"), targetSel=$("target"), engage=$("engage"), hint=$("hint");
+const levelBig=$("levelBig"), targetSel=$("target"), engage=$("engage");
 const manual=$("manual"), manualVal=$("manualVal");
 const modesEl=$("modes"), modePill=$("modePill"), sensorEl=$("sensor");
 const meterFill=$("meterFill"), meterTxt=$("meterTxt"), cam=$("cam"), bandsCv=$("bands");
@@ -37,6 +37,8 @@ const devsEl=$("devs"), devCount=$("devCount"), puffs=$("puffs");
 
 // ───────────────────────── connection ─────────────────────────
 function connect() {
+  clearTimeout(reconnectTimer);
+  if (ws) { ws.onclose = ws.onerror = null; try { ws.close(); } catch {} }  // drop any old socket cleanly
   room = new URL(location).searchParams.get("room")
        || localStorage.getItem("mm_room") || "workshop";
   roomName.textContent = room;
@@ -44,10 +46,20 @@ function connect() {
   setConn("…", "saying hi…");
   ws = new WebSocket(url);
   ws.onopen    = () => setConn("ok", "connected");
-  ws.onclose   = () => { setConn("off", "reconnecting…"); setTimeout(connect, 2000); };
-  ws.onerror   = () => ws.close();
+  ws.onclose   = () => { setConn("off", "reconnecting…"); reconnectTimer = setTimeout(connect, 2000); };
+  ws.onerror   = () => { try { ws.close(); } catch {} };
   ws.onmessage = (e) => onMessage(e.data);
 }
+
+// One shared AudioContext for mic + music modes. iOS only unlocks audio inside a
+// user gesture, so we create/resume it on the tap (and on any later gesture).
+function getAudioCtx() {
+  if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  if (audioCtx.state === "suspended") audioCtx.resume();
+  return audioCtx;
+}
+["pointerdown", "touchend"].forEach(ev => addEventListener(ev,
+  () => { if (audioCtx && audioCtx.state === "suspended") audioCtx.resume(); }, { passive: true }));
 function setConn(cls, txt) { connEl.className = "conn " + cls; connTxt.textContent = txt; }
 
 function onMessage(raw) {
@@ -66,17 +78,18 @@ function isNew(key, val) {
 }
 
 function dispatch() {
+  if (!ws || ws.readyState !== 1) return;             // don't book-keep sends that can't leave
   const now = performance.now();
   if (now - lastSendAt < MIN_INTERVAL) return;
   const force = now - lastKeepAlive > KEEPALIVE_MS;   // periodic anti-drift resend
 
-  if (route === "sync" || makers.length < 2) {
+  if (route === "sync" || makers.length < 2 || (route === "spectrum" && !bands)) {
     const lvl = Math.round(energy), tgt = targetSel.value;
     const key = "s:" + tgt;
     if (force || isNew(key, lvl)) { wsSend({ t: "set", target: tgt, level: lvl }); seen.set(key, lvl); lastSendAt = now; }
   } else {
     const levels = {};
-    if (route === "spectrum" && bands) {
+    if (route === "spectrum") {   // bands present here (the null case fell into sync above)
       makers.forEach((d, i) => levels[d.id] = Math.round(bands[i % bands.length] || 0));
     } else { // phase: a traveling wave scaled by the input energy
       const sp = (spread.value / 100) * Math.PI;
@@ -97,6 +110,7 @@ function setRoster(list) {
   const ids = new Set(list.map(d => d.id));
   for (let i = makers.length - 1; i >= 0; i--) if (!ids.has(makers[i].id)) makers.splice(i, 1);
   for (const d of list) if (!makers.find(m => m.id === d.id)) makers.push({ ...d, level: 0, current_ma: 0, water: "?", rssi: 0 });
+  seen.clear();                                // forget send-history of any departed makers
   renderTargets(); renderDevs(); routeEl.hidden = makers.length < 2;
 }
 function updateMaker(m) {
@@ -146,11 +160,10 @@ const Manual = {
 
 function micAnalyser(fftSize) {
   return navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
-    const ctx = new (window.AudioContext || window.webkitAudioContext)();
-    ctx.resume();
+    const ctx = getAudioCtx();                 // shared, unlocked on the tap gesture (iOS)
     const an = ctx.createAnalyser(); an.fftSize = fftSize;
     ctx.createMediaStreamSource(stream).connect(an);
-    return { ctx, an, stream };
+    return { an, stream };                      // no ctx → teardown keeps the shared ctx alive
   });
 }
 
@@ -250,8 +263,8 @@ const Audio = {
   async start() {
     this.a = await micAnalyser(256); this.buf = new Uint8Array(this.a.an.frequencyBinCount);
     bandsCv.hidden = false; this.ctx2d = bandsCv.getContext("2d");
-    bandsCv.width = bandsCv.clientWidth * devicePixelRatio; bandsCv.height = 70 * devicePixelRatio;
-    if (makers.length >= 2) setRoute("spectrum");
+    bandsCv.width = (bandsCv.clientWidth || 320) * devicePixelRatio; bandsCv.height = 70 * devicePixelRatio;
+    if (makers.length >= 2) { this.prevRoute = route; setRoute("spectrum"); }
   },
   read() {
     if (!this.a) return;
@@ -268,7 +281,8 @@ const Audio = {
     energy = out.reduce((p, c) => p + c, 0) / N;
     drawBands(this.ctx2d, out);
   },
-  stop() { teardown(this.a); this.a = null; bands = null; bandsCv.hidden = true; },
+  stop() { teardown(this.a); this.a = null; bands = null; bandsCv.hidden = true;
+           if (this.prevRoute) { setRoute(this.prevRoute); this.prevRoute = null; } },
 };
 
 const SOURCES = { mic: Mic, light: Light, motion: Motion, face: Face, audio: Audio };
@@ -290,19 +304,24 @@ function drawBands(cx, arr) {
 async function selectMode(key) {
   const next = SOURCES[key];
   if (source === next) return setManual();          // tapping the active mode → back to slider
+  const myGen = ++modeGen;                            // cancel-token: the newest tap wins
+  if (key === "mic" || key === "audio") getAudioCtx(); // unlock audio inside this tap (iOS)
   if (source) source.stop();
+  source = next;                                      // tick reads it; each read() self-guards until ready
   // reset per-mode UI
   invertRow.hidden = true; bandsCv.hidden = true; sensorHint.textContent = "";
   inverted = false; invertBtn.setAttribute("aria-checked", "false");
+  sensorEl.hidden = false;
+  [...modesEl.children].forEach(b => b.classList.toggle("on", b.dataset.mode === key));
+  modePill.textContent = next.name;
+  if (next.invert) { invertRow.hidden = false; invLbl.textContent = next.invLabel || "invert"; }
   try {
-    source = next; sensorEl.hidden = false;
-    [...modesEl.children].forEach(b => b.classList.toggle("on", b.dataset.mode === key));
-    modePill.textContent = next.name;
-    if (next.invert) { invertRow.hidden = false; invLbl.textContent = next.invLabel || "invert"; }
     await next.start();
+    if (myGen !== modeGen) { next.stop(); return; }   // a newer mode took over mid-start → clean up
     sensorHint.textContent = next.hint || "";
-    running = true; setEngage();                     // auto-start so it "just works"
+    running = true; setEngage();                      // auto-start so it "just works"
   } catch (err) {
+    if (myGen !== modeGen) return;                     // superseded; the newer call owns the UI
     sensorHint.textContent = "⚠ " + (err.message || "Couldn't start that sensor.");
     setManual();
   }
@@ -340,7 +359,7 @@ $("roomSave").onclick = (e) => {
   const v = $("roomInput").value.trim(); if (!v) return;
   localStorage.setItem("mm_room", v);
   const u = new URL(location); u.searchParams.set("room", v); history.replaceState(0, "", u);
-  if (ws) ws.close(); connect();
+  connect();                                          // connect() cleanly drops the old socket + timer
 };
 
 function setFill(el) { el.style.setProperty("--fill", ((el.value - el.min) / (el.max - el.min) * 100) + "%"); }

--- a/extras/phone-app/public/favicon.svg
+++ b/extras/phone-app/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#58c4e0"/>
+  <path d="M9.5 22h12.2a4.1 4.1 0 0 0 .4-8.2A5.8 5.8 0 0 0 8.4 12.6 3.9 3.9 0 0 0 9.5 22Z" fill="#edfaff"/>
+</svg>

--- a/extras/phone-app/public/index.html
+++ b/extras/phone-app/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#58c4e0">
 <title>Mist Control · ByProduct Lab</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/extras/phone-app/public/index.html
+++ b/extras/phone-app/public/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1">
+<meta name="theme-color" content="#58c4e0">
+<title>Mist Control · ByProduct Lab</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Young+Serif&family=Inter:wght@400;500;600;700&family=Knewave&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="app.css">
+</head>
+<body>
+<!-- dreamy sky field + drifting clouds + film grain (pure CSS, matches the shop) -->
+<div class="sky" aria-hidden="true"></div>
+<div class="clouds" aria-hidden="true"><span></span><span></span><span></span></div>
+<div class="grain" aria-hidden="true"></div>
+
+<header class="bar">
+  <div class="mark"><svg class="cloud-ico" viewBox="0 0 24 24"><path d="M7 18h9a4 4 0 0 0 .4-8A5.5 5.5 0 0 0 6 9.3 3.8 3.8 0 0 0 7 18Z"/></svg>Mist&nbsp;Control</div>
+  <button class="chip" id="roomBtn" title="Change room">☁ <b id="roomName">workshop</b></button>
+  <div class="conn" id="conn"><i></i><span id="connTxt">saying hi…</span></div>
+</header>
+
+<main>
+  <!-- ☁ the live hero: what the mist is doing right now ☁ -->
+  <section class="card hero">
+    <div class="eyebrow">now misting</div>
+    <div class="level"><b id="levelBig">0</b><span>%</span></div>
+    <div class="puffs" id="puffs" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div>
+    <div class="targetline">
+      sending to <select id="target" class="sel"><option value="all">every maker</option></select>
+    </div>
+    <button id="engage" class="btn big">Start misting</button>
+    <div class="hint" id="hint">Pick who to send to, then tap Start — or just slide below.</div>
+  </section>
+
+  <!-- ☁ MANUAL ☁ the always-there slider -->
+  <section class="card">
+    <div class="phead"><h2>Slide it</h2><div class="pval" id="manualVal">30%</div></div>
+    <input type="range" id="manual" class="slider" min="0" max="100" value="30">
+    <div class="ticks"><span>off</span><span>gentle</span><span>full</span></div>
+  </section>
+
+  <!-- ☁ SENSE ☁ phone senses → mist -->
+  <section class="card">
+    <div class="phead"><h2>Play with it</h2><div class="pill" id="modePill">slider</div></div>
+    <div class="modes" id="modes">
+      <button data-mode="mic"    class="mode"><svg viewBox="0 0 24 24"><path d="M12 3a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V6a3 3 0 0 0-3-3Z"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3"/></svg><b>Mic</b><small>blow on it!</small></button>
+      <button data-mode="light"  class="mode"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5 19 19M19 5l-1.5 1.5M6.5 17.5 5 19"/></svg><b>Light</b><small>cover the cam</small></button>
+      <button data-mode="motion" class="mode"><svg viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="3"/><path d="M12 6v6l3 2"/></svg><b>Tilt</b><small>lean &amp; shake</small></button>
+      <button data-mode="face"   class="mode"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9 10h.01M15 10h.01M8 14a5 5 0 0 0 8 0"/></svg><b>Face</b><small>open wide</small></button>
+      <button data-mode="audio"  class="mode"><svg viewBox="0 0 24 24"><path d="M4 12v0M8 8v8M12 5v14M16 9v6M20 11v2"/></svg><b>Music</b><small>visualizer</small></button>
+    </div>
+
+    <!-- live sense readout + mapping, shown when a mode is on -->
+    <div class="sensor" id="sensor" hidden>
+      <div class="meter"><i id="meterFill"></i><b id="meterTxt">—</b></div>
+      <video id="cam" playsinline muted hidden></video>
+      <canvas id="bands" class="bands" hidden></canvas>
+      <div class="srow">
+        <label>sensitivity</label>
+        <input type="range" id="gain" class="slider thin" min="1" max="100" value="50">
+      </div>
+      <div class="srow" id="invertRow" hidden>
+        <label id="invLbl">flip it</label>
+        <button id="invert" class="toggle" role="switch" aria-checked="false"></button>
+      </div>
+      <div class="hint" id="sensorHint"></div>
+    </div>
+  </section>
+
+  <!-- ☁ MAKERS ☁ many makers, one phone -->
+  <section class="card">
+    <div class="phead"><h2>Your makers</h2><div class="pval"><b id="devCount">0</b> online</div></div>
+    <div class="route" id="route" hidden>
+      <button data-route="sync"     class="rbtn on">Together<small>all in sync</small></button>
+      <button data-route="phase"    class="rbtn">Wave<small>ripple / delay</small></button>
+      <button data-route="spectrum" class="rbtn">Spectrum<small>one band each</small></button>
+    </div>
+    <div class="phasectl srow" id="phaseCtl" hidden>
+      <label>spread</label>
+      <input type="range" id="spread" class="slider thin" min="0" max="100" value="60">
+    </div>
+    <ul class="devs" id="devs"><li class="empty">No makers yet — flash one &amp; power it on ☁</li></ul>
+  </section>
+</main>
+
+<footer class="foot">
+  <span class="sig">PMM.BY.DS</span>
+  <span id="budget">runs free on Cloudflare</span>
+</footer>
+
+<!-- room change dialog -->
+<dialog id="roomDlg" class="dlg">
+  <form method="dialog">
+    <h3>Room name</h3>
+    <p>Every phone &amp; maker sharing a room name share control. Pick a secret one for a private session.</p>
+    <input id="roomInput" class="text" autocomplete="off" spellcheck="false">
+    <menu><button value="cancel" class="btn ghost">Cancel</button><button id="roomSave" value="save" class="btn">Join</button></menu>
+  </form>
+</dialog>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/extras/phone-app/public/index.html
+++ b/extras/phone-app/public/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#58c4e0">
 <title>Mist Control · ByProduct Lab</title>
+<link rel="icon" href="favicon.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Young+Serif&family=Inter:wght@400;500;600;700&family=Knewave&display=swap" rel="stylesheet">
@@ -29,7 +30,7 @@
     <div class="level"><b id="levelBig">0</b><span>%</span></div>
     <div class="puffs" id="puffs" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div>
     <div class="targetline">
-      sending to <select id="target" class="sel"><option value="all">every maker</option></select>
+      sending to <select id="target" class="sel" aria-label="Which makers to send to"><option value="all">every maker</option></select>
     </div>
     <button id="engage" class="btn big">Start misting</button>
     <div class="hint" id="hint">Pick who to send to, then tap Start — or just slide below.</div>
@@ -38,7 +39,7 @@
   <!-- ☁ MANUAL ☁ the always-there slider -->
   <section class="card">
     <div class="phead"><h2>Slide it</h2><div class="pval" id="manualVal">30%</div></div>
-    <input type="range" id="manual" class="slider" min="0" max="100" value="30">
+    <input type="range" id="manual" class="slider" min="0" max="100" value="30" aria-label="Mist level">
     <div class="ticks"><span>off</span><span>gentle</span><span>full</span></div>
   </section>
 
@@ -60,7 +61,7 @@
       <canvas id="bands" class="bands" hidden></canvas>
       <div class="srow">
         <label>sensitivity</label>
-        <input type="range" id="gain" class="slider thin" min="1" max="100" value="50">
+        <input type="range" id="gain" class="slider thin" min="1" max="100" value="50" aria-label="Sensitivity">
       </div>
       <div class="srow" id="invertRow" hidden>
         <label id="invLbl">flip it</label>
@@ -80,7 +81,7 @@
     </div>
     <div class="phasectl srow" id="phaseCtl" hidden>
       <label>spread</label>
-      <input type="range" id="spread" class="slider thin" min="0" max="100" value="60">
+      <input type="range" id="spread" class="slider thin" min="0" max="100" value="60" aria-label="Wave spread">
     </div>
     <ul class="devs" id="devs"><li class="empty">No makers yet — flash one &amp; power it on ☁</li></ul>
   </section>

--- a/extras/phone-app/src/worker.js
+++ b/extras/phone-app/src/worker.js
@@ -57,13 +57,14 @@ export class Room {
   }
 
   // Phones need the live list of mist makers to map sensors → devices.
-  broadcastRoster() {
-    const devices = this.peers("device").map((ws) => {
-      const m = this.meta(ws);
-      return { id: m.id, name: m.name };
-    });
+  // `except` = a socket that's closing (getWebSockets() still lists it during
+  // webSocketClose) — drop it so a departed maker doesn't linger in the roster.
+  broadcastRoster(except) {
+    const devices = this.peers("device")
+      .filter((ws) => ws !== except)
+      .map((ws) => { const m = this.meta(ws); return { id: m.id, name: m.name }; });
     const msg = JSON.stringify({ t: "roster", devices });
-    for (const ws of this.peers("phone")) this.t(ws, msg);
+    for (const ws of this.peers("phone")) if (ws !== except) this.t(ws, msg);
   }
 
   async webSocketMessage(ws, raw) {
@@ -84,8 +85,8 @@ export class Room {
     }
   }
 
-  async webSocketClose(ws) { this.broadcastRoster(); }
-  async webSocketError(ws) { this.broadcastRoster(); }
+  async webSocketClose(ws) { this.broadcastRoster(ws); }
+  async webSocketError(ws) { this.broadcastRoster(ws); }
 
   // send, ignoring sockets that have already gone away
   t(ws, msg) {

--- a/extras/phone-app/src/worker.js
+++ b/extras/phone-app/src/worker.js
@@ -1,0 +1,94 @@
+// Mist Maker relay — a Cloudflare Worker + Durable Object.
+//
+// Think of the Durable Object "Room" as a chat room that two kinds of clients
+// join over a WebSocket:
+//   * phones  — send commands  ({t:"set", target, level} / {t:"multi", levels})
+//   * devices — the mist makers, which receive commands and report status
+//
+// Rule of the room: a phone's message is forwarded to every device; a device's
+// message is forwarded to every phone. That's the whole relay. The phone does
+// all the thinking (sensors, FFT, choreography); devices just obey + report.
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // /ws → join the WebSocket room. Everything else → the web app (static).
+    if (url.pathname === "/ws") {
+      if (request.headers.get("Upgrade") !== "websocket") {
+        return new Response("expected websocket", { status: 426 });
+      }
+      const room = url.searchParams.get("room") || "workshop";
+      const stub = env.ROOM.get(env.ROOM.idFromName(room));
+      return stub.fetch(request);
+    }
+    return env.ASSETS.fetch(request);
+  },
+};
+
+export class Room {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  // A client joins. We tag its socket with role/id/name and accept it with the
+  // hibernation API so the room costs nothing while idle.
+  async fetch(request) {
+    const url = new URL(request.url);
+    const role = url.searchParams.get("role") === "device" ? "device" : "phone";
+    const id = (url.searchParams.get("id") || crypto.randomUUID().slice(0, 4)).slice(0, 12);
+    const name = (url.searchParams.get("name") || (role === "device" ? "Mist" : "Phone")).slice(0, 32);
+
+    const [client, server] = Object.values(new WebSocketPair());
+    this.state.acceptWebSocket(server);
+    server.serializeAttachment({ role, id, name });
+
+    this.broadcastRoster(); // let phones see the updated device list
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  meta(ws) {
+    return ws.deserializeAttachment() || {};
+  }
+
+  peers(role) {
+    return this.state.getWebSockets().filter((ws) => this.meta(ws).role === role);
+  }
+
+  // Phones need the live list of mist makers to map sensors → devices.
+  broadcastRoster() {
+    const devices = this.peers("device").map((ws) => {
+      const m = this.meta(ws);
+      return { id: m.id, name: m.name };
+    });
+    const msg = JSON.stringify({ t: "roster", devices });
+    for (const ws of this.peers("phone")) this.t(ws, msg);
+  }
+
+  async webSocketMessage(ws, raw) {
+    const from = this.meta(ws);
+    let data;
+    try { data = JSON.parse(raw); } catch { return; }
+
+    if (from.role === "phone") {
+      // command → every device (each device decides if it's the target)
+      const out = JSON.stringify(data);
+      for (const dev of this.peers("device")) this.t(dev, out);
+    } else {
+      // status → every phone, stamped with which maker it came from
+      data.id = from.id;
+      data.name = from.name;
+      const out = JSON.stringify(data);
+      for (const ph of this.peers("phone")) this.t(ph, out);
+    }
+  }
+
+  async webSocketClose(ws) { this.broadcastRoster(); }
+  async webSocketError(ws) { this.broadcastRoster(); }
+
+  // send, ignoring sockets that have already gone away
+  t(ws, msg) {
+    try { ws.send(msg); } catch {}
+  }
+}

--- a/extras/phone-app/wrangler.toml
+++ b/extras/phone-app/wrangler.toml
@@ -1,0 +1,29 @@
+# Cloudflare Worker config for the Mist Maker phone-sensor relay.
+#
+# This one Worker does TWO jobs:
+#   1. Serves the phone web app (the files in ./public) over HTTPS.
+#   2. Runs a WebSocket "room" (the Durable Object below) that passes messages
+#      between your phone and your mist makers — like an MQTT broker, but built
+#      into Cloudflare so there's no extra service to sign up for.
+#
+# Deploy:  npx wrangler deploy      (see README.md for the full walkthrough)
+
+name = "mistmaker-relay"
+main = "src/worker.js"
+compatibility_date = "2025-01-01"
+
+# The web app — served as static files straight from Cloudflare's edge.
+[assets]
+directory = "./public"
+binding = "ASSETS"
+
+# The "room" where phone + mist makers meet. One instance per room name.
+[[durable_objects.bindings]]
+name = "ROOM"
+class_name = "Room"
+
+# Durable Objects must be declared once via a migration. SQLite-backed classes
+# work on the free plan (we don't store anything — the room is just a relay).
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["Room"]

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -136,6 +136,12 @@ public:
   float lastProbeMa() const { return _lastProbeMa; }
 
   // ------------------- battery (needs a battery pin) -------------------
+  // Turn battery sensing OFF at runtime. Battery Kit V0.3's D1 divider can't
+  // tell USB-C power from a real cell, so the reading is unreliable (it caused
+  // false low-battery shutdowns). After this call every battery_* method
+  // behaves exactly as on a board with no cell: readBatteryVolts()/percent()
+  // return 0 and batteryState() returns MIST_BATT_UNKNOWN (never CRITICAL).
+  void disableBattery() { _battPin = -1; }
   // Divider ratio = (Rtop+Rbottom)/Rbottom. Battery Kit V0.3 uses 2.0 (1:1).
   void setBatteryDivider(float ratio) { _battDivider = ratio; }
   // Thresholds in volts (defaults: low 3.45 V, critical 3.20 V under load).


### PR DESCRIPTION
Two changes for the workshop, built on one branch (6 atomic commits, all 10 examples compile on XIAO ESP32-C6).

## 1. Remove V0.3 battery sensing + deep-sleep from examples
Battery Kit V0.3 reads `BATT+÷2` on D1, but the TPS2116 power mux means the board runs off USB-C whenever it's plugged in — so D1 can't tell "USB-only, no cell" from "on battery, dying," which caused false low-battery shutdowns. Deep-sleep also makes a board awkward to reflash mid-workshop.

- `MistMaker::disableBattery()` — sets the battery pin to `-1` at runtime, so every `battery*` method behaves as on a no-cell board (volts/pct read 0, `batteryState()` is `UNKNOWN`, never `CRITICAL`). Mist/water/current behaviour unchanged.
- `MistBlink`, `MistDimming`, `WaterDetect` call it in `setup()`.
- `WiFiPhoneControl`, `HomeAssistant_MQTT`: battery row/sensor + watchdog + `gracefulPowerOff()`/`esp_deep_sleep_start()` removed; AP/slider/toggle/water-detect + MQTT light/water sensor kept.
- **TODO(V0.4):** re-add battery brown-out + deep-sleep once the board has a USB-present pin.

## 2. `PhoneSensors` example + Cloudflare phone-sensor web app (`extras/phone-app/`)
Drive the mist from a phone's **mic / ambient light / tilt / face expressions / music spectrum**, and choreograph many makers from one phone (in sync, as a delay/wave, or as a vapour equaliser).

**Why a cloud relay** (not the board's own AP, not MQTT): phone sensors need a secure (HTTPS) context, which a board's plain-HTTP AP can't serve — iOS/Android refuse sensor access there. So the app is hosted on Cloudflare and every maker connects *out* over WSS to a Durable-Object "room". Mist reacts slowly, so cloud jitter is invisible and all makers sync via the room — no ESP-NOW. One `wrangler deploy` serves both the app and the relay.

- `examples/PhoneSensors/PhoneSensors.ino` — one universal thin-client sketch per maker (joins the room, applies 0-100 levels, reports level/current/water/RSSI, rich Serial debug, WiFi timeout + disconnect/command fail-safe watchdog, 30 s water re-probe). Needs **"WebSockets" by Markus Sattler**.
- `extras/phone-app/src/worker.js` — Worker + Durable Object room (~95 lines, hibernation API).
- `extras/phone-app/public/` — cute vanilla web app mirroring shop.byproductlab.com (Young Serif / Inter / Knewave, mist palette). Default mist level 30%.
- `extras/phone-app/README.md` — plain-English deploy + flash + usage walkthrough.

**Free-tier safe:** Durable Objects get their own 100k requests/day; incoming WS messages bill 20:1 (~2M msgs/day free); outgoing + static serving free. App caps sends at 8 Hz + send-on-change.

## Verification
- `arduino-cli`: **10/10 examples compile** on XIAO_ESP32C6 (esp32 core 3.3.10); CI updated to install the WebSockets lib.
- Reviewed with `/code-review` (3 reviewers) + `/codex:review` — all findings fixed (XSS escaping, async mode-switch cancel-token, WS reconnect de-dup, iOS audio unlock, firmware disconnect fail-safe + water re-probe).
- Relay tested end-to-end with `wrangler dev` + simulated phone/makers (8/8 protocol assertions) and driven live in a browser (render + connect + roster confirmed).

> Part 1 is independently mergeable if you'd rather land it first and review the phone app separately — happy to split into two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
