### PR TITLE
MistMaker v2.0.0: V0.4 ST power-source sensing + library cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 >   milliamps via the 3.0 V/A sense factor. Convert old thresholds with
 >   `mA ≈ oldVolts × 166.7` (e.g. an old `> 0.4` check becomes `> 67` mA).
 > - The constructor's last argument (duty cap) now **takes effect** — 1.x
->   accepted and ignored it. Valid caps are `1..(2^pwmRes − 1)`; anything
->   else (including omitting it) resolves to the 50% efficiency knee, which is
->   exactly the 1.x behavior. If an old sketch passed a valid value like
->   `255` "for full power", it will now really drive that duty — remove the
->   argument to keep the 1.x drive level.
+>   accepted and ignored it. Valid caps are `1..90% of full scale` (higher
+>   requests clamp to 90% — above it the drive makes heat, not mist);
+>   zero/negative/omitted resolve to the 50% efficiency knee, which is exactly
+>   the 1.x behavior. If an old sketch passed a valid value like `200`, it
+>   will now really drive that duty — remove the argument to keep 1.x drive.
 > - Everything else is source-compatible.
 
 ---
@@ -50,7 +50,7 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 
 // One line per board — pick yours:
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + call disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off — no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -133,7 +133,7 @@ always means "my current maximum."
 ## 🔋 Battery Monitoring (Battery Kit)
 
 ```cpp
-float v   = mist.readBatteryVolts();   // calibrated mV via the on-board divider
+float v   = mist.readBatteryVolts();   // calibrated volts via the on-board divider
 uint8_t p = mist.batteryPercent();     // rough LiPo gauge for UIs
 
 if (mist.batteryCritical()) {          // hysteresis built in; false on USB
@@ -155,9 +155,10 @@ calibrated `analogReadMilliVolts()` (linear even on the C6).
 >   `MistMakerBatteryKitV04()` preset self-gates: `batteryState()` returns
 >   `MIST_BATT_CHARGING` on USB and only ever reports `LOW`/`CRITICAL` on the
 >   cell. Use `usbPresent()` / `onBattery()` to read the source yourself.
-> - **Battery Kit V0.3** has no ST pin, so call `mist.disableBattery();` before
->   `begin()` to switch battery sensing off (every `battery*` call then behaves
->   as on a board with no cell).
+> - **Battery Kit V0.3** has no ST pin, so its preset ships with battery
+>   sensing **off** (every `battery*` call behaves as on a board with no
+>   cell). `disableBattery()` remains for switching it off at runtime on
+>   custom builds.
 
 ---
 
@@ -230,7 +231,8 @@ probe/calibration timing constants sit at the top of `MistMaker.cpp`.
 ```cpp
 // --- construction ---
 MistMaker(const MistMakerPins &pins, uint32_t pwmFreq = 108700,
-          uint8_t pwmRes = 8, int dutyMax = DUTY_AUTO); // AUTO = 50% efficiency knee
+          uint8_t pwmRes = 8,
+          int dutyMax = MistMakerDefaults::DUTY_AUTO); // AUTO = 50% efficiency knee
 MistMaker(int mistPin, int enPin, int sensePin, int ledPin, ...); // bare pins
 
 // --- control ---
@@ -257,7 +259,7 @@ bool    usbPresent();            // load on USB (mux VIN1)? true if no sense pin
 bool    onBattery();             // load on the cell (mux VIN2)? = valid SoC
 
 // --- battery ---
-float   readBatteryVolts(uint8_t samples = 16);    // calibrated mV
+float   readBatteryVolts(uint8_t samples = 16);    // calibrated volts
 uint8_t batteryPercent();
 MistBatteryState batteryState(); // OK/LOW/CRITICAL/CHARGING, ST-gated + hysteresis
 bool    batteryLow();   bool batteryCritical();

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 - **Power-source sensing** — reads the TPS2116 mux status (Battery Kit V0.4) so battery logic knows USB from the cell and never false-triggers
 - **Pin presets for every official board variant** — one line to target your PCB
 - Designed for ESP32-based boards (tested on Seeed Studio XIAO ESP32-C6)
-- Modular and reusable class-based structure; v1.0 sketches compile unchanged
+- Modular and reusable class-based structure
+
+> **Upgrading to v2.0?** Two renames: `applyLevel(x)` → `setLevel(x)` and
+> `readCurrentVoltage()` → `readCurrentMa()`. The constructor's last argument
+> now genuinely sets the duty cap (it was ignored in 1.x). Everything else is
+> source-compatible.
 
 ---
 
@@ -189,11 +194,14 @@ If you are using a different board and wish to adapt the library, you may need t
 
 ## 🧪 API Reference
 
+All defaults live in `namespace MistMakerDefaults` (top of `MistMaker.h`) —
+one documented place for every tuning value the library assumes.
+
 ```cpp
 // --- construction ---
-MistMaker(const MistMakerPins &pins, int pwmFreq = 108700,
-          int pwmRes = 8, int duty = 127);
-MistMaker(int mistPin, int enPin, int sensePin, int ledPin, ...); // v1.0
+MistMaker(const MistMakerPins &pins, uint32_t pwmFreq = 108700,
+          uint8_t pwmRes = 8, uint8_t dutyMax = 127);
+MistMaker(int mistPin, int enPin, int sensePin, int ledPin, ...); // bare pins
 
 // --- control ---
 void begin();

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 >   `mA ≈ oldVolts × 166.7` (e.g. an old `> 0.4` check becomes `> 67` mA).
 > - The constructor's last argument (duty cap) now **takes effect** — 1.x
 >   accepted and ignored it. Valid caps are `1..(2^pwmRes − 1)`; anything
->   else (including omitting it) resolves to the 50% sweet spot, which is
+>   else (including omitting it) resolves to the 50% efficiency knee, which is
 >   exactly the 1.x behavior. If an old sketch passed a valid value like
 >   `255` "for full power", it will now really drive that duty — remove the
 >   argument to keep the 1.x drive level.
@@ -209,7 +209,7 @@ probe/calibration timing constants sit at the top of `MistMaker.cpp`.
 ```cpp
 // --- construction ---
 MistMaker(const MistMakerPins &pins, uint32_t pwmFreq = 108700,
-          uint8_t pwmRes = 8, int dutyMax = DUTY_AUTO); // AUTO = 50% sweet spot
+          uint8_t pwmRes = 8, int dutyMax = DUTY_AUTO); // AUTO = 50% efficiency knee
 MistMaker(int mistPin, int enPin, int sensePin, int ledPin, ...); // bare pins
 
 // --- control ---
@@ -217,7 +217,7 @@ void begin();
 void turnOn();  void turnOff();  void toggle();  bool isOn();
 void setLevel(uint8_t level);    // 0..255 dimming
 uint8_t getLevel();
-void setMaxDuty(uint8_t duty);   // default 127 (50% = resonant sweet spot)
+void setMaxDuty(int duty);       // default 127; past 50% = 5x power, hot L1
 void printStatus();
 
 // --- current sense / detection ---

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 #include <MistMaker.h>
 
 // One line per board — pick yours:
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also call disableBattery()
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + call disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 - **Mist dimming** — `setLevel(0..255)`, dim mist like an LED
 - **Current sensing in mA** with auto or manual calibration
 - **Piezo disc + water detection** — one ADC pin tells you if a disc is attached, if it fell off, and if the water ran out
-- **Battery monitoring** — voltage, percent estimate, and a graceful low-battery shutdown to prevent brown-outs
+- **Battery monitoring** — calibrated voltage, percent estimate, and a graceful low-battery shutdown to prevent brown-outs
+- **Power-source sensing** — reads the TPS2116 mux status (Battery Kit V0.4) so battery logic knows USB from the cell and never false-triggers
 - **Pin presets for every official board variant** — one line to target your PCB
 - Designed for ESP32-based boards (tested on Seeed Studio XIAO ESP32-C6)
 - Modular and reusable class-based structure; v1.0 sketches compile unchanged
@@ -34,7 +35,8 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 #include <MistMaker.h>
 
 // One line per board — pick yours:
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also call disableBattery()
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -96,24 +98,31 @@ mist.setCurrentSenseFactor(3.0);  // INA180A3 (100 V/V) × 30 mΩ
 ## 🔋 Battery Monitoring (Battery Kit)
 
 ```cpp
-float v   = mist.readBatteryVolts();   // via on-board divider
+float v   = mist.readBatteryVolts();   // calibrated mV via the on-board divider
 uint8_t p = mist.batteryPercent();     // rough LiPo gauge for UIs
 
-if (mist.batteryCritical()) {          // hysteresis built in
+if (mist.batteryCritical()) {          // hysteresis built in; false on USB
   mist.shutdown();                     // mist off + boost rail off
   esp_deep_sleep_start();              // sleep instead of brown-out
 }
 ```
 
 Defaults: divider ratio 2.0, low = 3.45 V, critical = 3.20 V. Override with
-`setBatteryDivider()` / `setBatteryThresholds()`.
+`setBatteryDivider()` / `setBatteryThresholds()`. Reads use the ESP32's
+calibrated `analogReadMilliVolts()` (linear even on the C6).
 
-> ⚠️ **Battery Kit V0.3:** the D1 divider reads `BATT+`, but the TPS2116 power
-> mux means the board runs off USB-C whenever it's plugged in — so D1 can't tell
-> "USB-only, no cell" from "on battery, dying," which caused false low-battery
-> shutdowns. Until V0.4 adds a USB-present pin, call `mist.disableBattery();`
-> before `begin()` to switch battery sensing off (every `battery*` call then
-> behaves as on a board with no cell). The networked examples already do this.
+> **Why the board can't just read `BATT+`:** the TPS2116 power mux runs the
+> board off USB-C whenever it's plugged in, so `BATT+` tracks the *charger* (not
+> state-of-charge) on USB — reading it blindly caused false low-battery
+> shutdowns.
+>
+> - **Battery Kit V0.4** routes the mux **ST** (status) pin to **D8**, so the
+>   `MistMakerBatteryKitV04()` preset self-gates: `batteryState()` returns
+>   `MIST_BATT_CHARGING` on USB and only ever reports `LOW`/`CRITICAL` on the
+>   cell. Use `usbPresent()` / `onBattery()` to read the source yourself.
+> - **Battery Kit V0.3** has no ST pin, so call `mist.disableBattery();` before
+>   `begin()` to switch battery sensing off (every `battery*` call then behaves
+>   as on a board with no cell).
 
 ---
 
@@ -204,13 +213,19 @@ bool  discPresent();
 MistSenseState senseState();
 float lastProbeMa();
 
+// --- power source (mux status, V0.4+) ---
+void    setUsbSensePin(int8_t pin);                // TPS2116 ST (Battery Kit V0.4 = D8)
+bool    usbPresent();            // load on USB (mux VIN1)? true if no sense pin
+bool    onBattery();             // load on the cell (mux VIN2)? = valid SoC
+
 // --- battery ---
-float   readBatteryVolts(uint8_t samples = 16);
+float   readBatteryVolts(uint8_t samples = 16);    // calibrated mV
 uint8_t batteryPercent();
-MistBatteryState batteryState(); // OK / LOW / CRITICAL, with hysteresis
+MistBatteryState batteryState(); // OK/LOW/CRITICAL/CHARGING, ST-gated + hysteresis
 bool    batteryLow();   bool batteryCritical();
 void    setBatteryDivider(float ratio);            // default 2.0
 void    setBatteryThresholds(float lowV, float critV);
+void    disableBattery();        // pre-V0.4 escape hatch (turns sensing off)
 void    shutdown();              // mist + boost + LED off (call before sleep)
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,19 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 - Designed for ESP32-based boards (tested on Seeed Studio XIAO ESP32-C6)
 - Modular and reusable class-based structure
 
-> **Upgrading to v2.0?** Two renames: `applyLevel(x)` → `setLevel(x)` and
-> `readCurrentVoltage()` → `readCurrentMa()`. The constructor's last argument
-> now genuinely sets the duty cap (it was ignored in 1.x). Everything else is
-> source-compatible.
+> **Upgrading to v2.0?**
+> - `applyLevel(x)` → `setLevel(x)` (true rename, same 0..255 meaning).
+> - `readCurrentVoltage()` is **removed, not renamed** — it returned the raw
+>   sense-pin voltage with a legacy ×2 scale; `readCurrentMa()` returns
+>   milliamps via the 3.0 V/A sense factor. Convert old thresholds with
+>   `mA ≈ oldVolts × 166.7` (e.g. an old `> 0.4` check becomes `> 67` mA).
+> - The constructor's last argument (duty cap) now **takes effect** — 1.x
+>   accepted and ignored it. Valid caps are `1..(2^pwmRes − 1)`; anything
+>   else (including omitting it) resolves to the 50% sweet spot, which is
+>   exactly the 1.x behavior. If an old sketch passed a valid value like
+>   `255` "for full power", it will now really drive that duty — remove the
+>   argument to keep the 1.x drive level.
+> - Everything else is source-compatible.
 
 ---
 
@@ -194,13 +203,13 @@ If you are using a different board and wish to adapt the library, you may need t
 
 ## 🧪 API Reference
 
-All defaults live in `namespace MistMakerDefaults` (top of `MistMaker.h`) —
-one documented place for every tuning value the library assumes.
+Hardware defaults live in `namespace MistMakerDefaults` (top of `MistMaker.h`);
+probe/calibration timing constants sit at the top of `MistMaker.cpp`.
 
 ```cpp
 // --- construction ---
 MistMaker(const MistMakerPins &pins, uint32_t pwmFreq = 108700,
-          uint8_t pwmRes = 8, uint8_t dutyMax = 127);
+          uint8_t pwmRes = 8, int dutyMax = DUTY_AUTO); // AUTO = 50% sweet spot
 MistMaker(int mistPin, int enPin, int sensePin, int ledPin, ...); // bare pins
 
 // --- control ---

--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ mist.setCurrentSenseFactor(3.0);  // INA180A3 (100 V/V) × 30 mΩ
 
 ---
 
+## 🌫️ How much mist can it make? (duty cap, measured)
+
+The PWM duty cap is the library's "how hard to drive" ceiling, and it was
+bench-characterized on real V0.4 hardware (2026-07-03 duty sweep, 0→90%):
+
+| Duty cap | What you get |
+|---|---|
+| **127 (50%) — the default** | The efficiency sweet spot: ~90% of practical mist at ~¼ of peak power, cool components, battery-sustainable (~0.3 A from the cell). Ships as `DUTY_AUTO`. |
+| **`MistMakerDefaults::DUTY_TURBO` (178 ≈ 70%)** | The **true mist maximum** — output rises all the way to ~70% duty on this drive. Costs ~4× the input power, needs a strong 5 V supply (≥ 2 A wall adapter); a battery reaches it only seconds at full charge. |
+| Above ~75% | Measurably *worse*: mist declines and turns unstable while current climbs toward 2 A — the resonant fly-back gets clipped and the energy becomes heat. The library hard-limits at 90% of full scale. |
+
+```cpp
+mist.setMaxDuty(MistMakerDefaults::DUTY_TURBO);  // wall-powered "turbo"
+mist.setMaxDuty(MistMakerDefaults::DUTY_AUTO);   // back to the 50% default
+```
+
+Setting a cap doesn't change your sketch's `setLevel(0..255)` scale — 255
+always means "my current maximum."
+
+---
+
 ## 🔋 Battery Monitoring (Battery Kit)
 
 ```cpp
@@ -217,7 +238,7 @@ void begin();
 void turnOn();  void turnOff();  void toggle();  bool isOn();
 void setLevel(uint8_t level);    // 0..255 dimming
 uint8_t getLevel();
-void setMaxDuty(int duty);       // default 127; past 50% = 5x power, hot L1
+void setMaxDuty(int duty);       // default 127 (50%); DUTY_TURBO=178 = measured peak
 void printStatus();
 
 // --- current sense / detection ---

--- a/examples/ESPNow_Control/ESPNow_Control.ino
+++ b/examples/ESPNow_Control/ESPNow_Control.ino
@@ -19,7 +19,7 @@ void onEspNowRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, 
   if (len < (int)sizeof(MistMsg)) return;
   MistMsg msg;
   memcpy(&msg, incomingData, sizeof(MistMsg));
-  mist.applyLevel(msg.level);
+  mist.setLevel(msg.level);
 }
 
 void setup() {

--- a/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
+++ b/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
@@ -6,15 +6,16 @@
 //     us an on/off toggle + brightness slider for free)
 //   * a water/disc status sensor (from current sensing)
 //
-// NOTE: battery sensing is intentionally OFF on this branch — Battery Kit V0.3
-// can't tell USB-C power from a real cell on D1, so the reading is unreliable.
-// TODO(V0.4): re-add the battery % sensor + low-battery deep-sleep once the
-// board has a real USB-present sense pin.
+// Battery: Battery Kit V0.4 routes the TPS2116 mux STATUS pin to D8, so the
+// library can tell USB from the cell. This example publishes a battery %
+// sensor and deep-sleeps on a critically low cell — batteryState() reads
+// CHARGING on USB, so it never sleeps while plugged in. On V0.3 (no ST pin)
+// switch the preset below and uncomment mist.disableBattery() in setup().
 //
 // Requirements:
 //   * MQTT broker (the standard Mosquitto add-on) + MQTT integration in HA
 //   * Arduino library: PubSubClient (Library Manager)
-//   * MistMaker >= 1.1.0
+//   * MistMaker >= 1.2.0
 //
 // Prefer YAML/no-code? See the ESPHome config in the main repo:
 // Programmable-Mist-Maker/firmware-examples/home-assistant/esphome-mistmaker.yaml
@@ -24,9 +25,11 @@
 #include <MistMaker.h>
 #include <WiFi.h>
 #include <PubSubClient.h>
+#include <esp_sleep.h>          // deep sleep on a critically low cell
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 
@@ -46,6 +49,7 @@ PubSubClient mqtt(wifi);
 
 char topicCmd[64], topicState[64], topicAvail[64], topicSensors[64];
 unsigned long lastSensorPub = 0;
+unsigned long lastBattMs = 0;
 
 const char* waterName(MistSenseState s) {
   switch (s) {
@@ -65,8 +69,12 @@ void publishState() {
 }
 
 void publishSensors() {
-  char buf[96];
-  snprintf(buf, sizeof(buf), "{\"water\":\"%s\"}", waterName(mist.senseState()));
+  char buf[128];
+  const bool charging = (mist.batteryState() == MIST_BATT_CHARGING);
+  snprintf(buf, sizeof(buf),
+           "{\"water\":\"%s\",\"battery\":%u,\"charging\":%s}",
+           waterName(mist.senseState()), mist.batteryPercent(),
+           charging ? "true" : "false");
   mqtt.publish(topicSensors, buf, true);
 }
 
@@ -94,6 +102,17 @@ void publishDiscovery() {
     "{\"name\":\"Mist Maker Water\",\"uniq_id\":\"%s_water\","
     "\"stat_t\":\"%s\",\"avty_t\":\"%s\","
     "\"val_tpl\":\"{{ value_json.water }}\",%s}",
+    DEV_ID, topicSensors, topicAvail, devBuf);
+  mqtt.publish(topic, payload, true);
+
+  // Battery % sensor (Battery Kit V0.4 with a cell). device_class battery gives
+  // HA the battery icon; the value rides on the same sensors topic.
+  snprintf(topic, sizeof(topic), "homeassistant/sensor/%s_battery/config", DEV_ID);
+  snprintf(payload, sizeof(payload),
+    "{\"name\":\"Mist Maker Battery\",\"uniq_id\":\"%s_batt\","
+    "\"dev_cla\":\"battery\",\"unit_of_meas\":\"%%\","
+    "\"stat_t\":\"%s\",\"avty_t\":\"%s\","
+    "\"val_tpl\":\"{{ value_json.battery }}\",%s}",
     DEV_ID, topicSensors, topicAvail, devBuf);
   mqtt.publish(topic, payload, true);
 }
@@ -134,10 +153,27 @@ void connectMqtt() {
   }
 }
 
+// Low-battery guard. batteryState() is ST-gated: it returns MIST_BATT_CHARGING
+// on USB, so this only fires on a genuinely dying cell — never while plugged in
+// to reflash. On CRITICAL: mark offline, mist off, radio off, deep-sleep to
+// protect the LiPo (recharge + reset/power-cycle wakes it).
+void checkBattery() {
+  if (mist.batteryState() != MIST_BATT_CRITICAL) return;
+  Serial.println("[BATTERY] Critical on cell - graceful shutdown.");
+  mqtt.publish(topicAvail, "offline", true);
+  mist.shutdown();
+  WiFi.disconnect(true);
+  WiFi.mode(WIFI_OFF);
+  delay(100);
+  esp_deep_sleep_start();
+}
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  mist.disableBattery();   // V0.3: D1 can't tell USB from battery (see note up top)
+  // On Battery Kit V0.3 (no ST pin) uncomment this so the unreliable D1 reading
+  // can't trigger a false low-battery shutdown:
+  // mist.disableBattery();
   mist.begin();
 
   snprintf(topicCmd,     sizeof(topicCmd),     "mistmaker/%s/set",     DEV_ID);
@@ -169,5 +205,11 @@ void loop() {
     lastSensorPub = millis();
     mist.probe();
     publishSensors();
+  }
+
+  // Low-battery guard every 5 s (no-op on USB / boards without a cell).
+  if (millis() - lastBattMs > 5000) {
+    lastBattMs = millis();
+    checkBattery();
   }
 }

--- a/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
+++ b/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
@@ -28,8 +28,8 @@
 #include <esp_sleep.h>          // deep sleep on a critically low cell
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 
@@ -50,6 +50,7 @@ PubSubClient mqtt(wifi);
 char topicCmd[64], topicState[64], topicAvail[64], topicSensors[64];
 unsigned long lastSensorPub = 0;
 unsigned long lastBattMs = 0;
+unsigned long lastMqttTry = 0;
 
 const char* waterName(MistSenseState s) {
   switch (s) {
@@ -70,6 +71,8 @@ void publishState() {
 
 void publishSensors() {
   char buf[128];
+  // battery% is voltage-derived; on USB it tracks the charger, not true SoC —
+  // the "charging" flag lets HA automations ignore the number while plugged in.
   const bool charging = (mist.batteryState() == MIST_BATT_CHARGING);
   snprintf(buf, sizeof(buf),
            "{\"water\":\"%s\",\"battery\":%u,\"charging\":%s}",
@@ -134,22 +137,23 @@ void onMqtt(char* topic, byte* payload, unsigned int len) {
   publishState();
 }
 
+// One (re)connect attempt + republish. Non-blocking by design: loop() retries
+// on a backoff, so the low-battery watchdog keeps running when WiFi or the
+// broker is down (a blocking connect loop would strand a weak cell).
 void connectMqtt() {
-  while (!mqtt.connected()) {
-    // LWT marks the device unavailable in HA if we drop off the network.
-    if (mqtt.connect(DEV_ID, MQTT_USER, MQTT_PASS,
-                     topicAvail, 0, true, "offline")) {
-      mqtt.publish(topicAvail, "online", true);
-      mqtt.subscribe(topicCmd);
-      publishDiscovery();
-      publishState();
-      publishSensors();
-      Serial.println("[MQTT] connected + discovery published");
-    } else {
-      Serial.print("[MQTT] connect failed rc=");
-      Serial.println(mqtt.state());
-      delay(2000);
-    }
+  if (mqtt.connected()) return;
+  // LWT marks the device unavailable in HA if we drop off the network.
+  if (mqtt.connect(DEV_ID, MQTT_USER, MQTT_PASS,
+                   topicAvail, 0, true, "offline")) {
+    mqtt.publish(topicAvail, "online", true);
+    mqtt.subscribe(topicCmd);
+    publishDiscovery();
+    publishState();
+    publishSensors();
+    Serial.println("[MQTT] connected + discovery published");
+  } else {
+    Serial.print("[MQTT] connect failed rc=");
+    Serial.println(mqtt.state());
   }
 }
 
@@ -158,9 +162,16 @@ void connectMqtt() {
 // to reflash. On CRITICAL: mark offline, mist off, radio off, deep-sleep to
 // protect the LiPo (recharge + reset/power-cycle wakes it).
 void checkBattery() {
-  if (mist.batteryState() != MIST_BATT_CRITICAL) return;
+  // Require TWO consecutive CRITICAL reads (~10 s) before the irreversible
+  // deep-sleep. A single sample can lie: the boost sags BATT+ under mist load,
+  // and on a V0.3 board the sense pin floats — neither should strand the board.
+  static uint8_t critStreak = 0;
+  if (mist.batteryState() != MIST_BATT_CRITICAL) { critStreak = 0; return; }
+  if (++critStreak < 2) return;
   Serial.println("[BATTERY] Critical on cell - graceful shutdown.");
   mqtt.publish(topicAvail, "offline", true);
+  mqtt.loop();
+  delay(150);              // let the retained 'offline' flush before the radio dies
   mist.shutdown();
   WiFi.disconnect(true);
   WiFi.mode(WIFI_OFF);
@@ -184,9 +195,17 @@ void setup() {
   WiFi.mode(WIFI_STA);
   WiFi.begin(WIFI_SSID, WIFI_PASS);
   Serial.print("WiFi");
-  while (WiFi.status() != WL_CONNECTED) { delay(300); Serial.print("."); }
-  Serial.print(" connected: ");
-  Serial.println(WiFi.localIP());
+  // Bounded wait: don't block boot forever on a dead AP — the ESP32 keeps
+  // auto-reconnecting, and loop()'s battery watchdog must stay reachable.
+  const uint32_t wifiT0 = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - wifiT0 < 20000) {
+    delay(300); Serial.print(".");
+  }
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.print(" connected: "); Serial.println(WiFi.localIP());
+  } else {
+    Serial.println(" not up yet - continuing; will retry in the background.");
+  }
 
   mqtt.setServer(MQTT_HOST, MQTT_PORT);
   mqtt.setBufferSize(640); // discovery payloads are bigger than the default
@@ -197,7 +216,12 @@ void setup() {
 }
 
 void loop() {
-  if (!mqtt.connected()) connectMqtt();
+  // Retry MQTT on a 2 s backoff (not every iteration) so a down broker can't
+  // starve the rest of loop(), including the low-battery watchdog below.
+  if (!mqtt.connected() && millis() - lastMqttTry > 2000) {
+    lastMqttTry = millis();
+    connectMqtt();
+  }
   mqtt.loop();
 
   // Publish sensors (and re-probe water) every 60 s.

--- a/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
+++ b/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
@@ -10,7 +10,7 @@
 // library can tell USB from the cell. This example publishes a battery %
 // sensor and deep-sleeps on a critically low cell — batteryState() reads
 // CHARGING on USB, so it never sleeps while plugged in. On V0.3 (no ST pin)
-// switch the preset below and uncomment mist.disableBattery() in setup().
+// switch the preset below — its preset ships with battery sensing off.
 //
 // Requirements:
 //   * MQTT broker (the standard Mosquitto add-on) + MQTT integration in HA
@@ -29,7 +29,7 @@
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 
@@ -184,7 +184,6 @@ void setup() {
   delay(1000);
   // On Battery Kit V0.3 (no ST pin) uncomment this so the unreliable D1 reading
   // can't trigger a false low-battery shutdown:
-  // mist.disableBattery();
   mist.begin();
 
   snprintf(topicCmd,     sizeof(topicCmd),     "mistmaker/%s/set",     DEV_ID);

--- a/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
+++ b/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
@@ -15,7 +15,7 @@
 // Requirements:
 //   * MQTT broker (the standard Mosquitto add-on) + MQTT integration in HA
 //   * Arduino library: PubSubClient (Library Manager)
-//   * MistMaker >= 1.2.0
+//   * MistMaker >= 2.0.0
 //
 // Prefer YAML/no-code? See the ESPHome config in the main repo:
 // Programmable-Mist-Maker/firmware-examples/home-assistant/esphome-mistmaker.yaml

--- a/examples/MistBlink/MistBlink.ino
+++ b/examples/MistBlink/MistBlink.ino
@@ -13,7 +13,7 @@
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -24,9 +24,7 @@ const unsigned long OFF_TIME_MS = 3000;
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
-  // can't cause a false low-battery shutdown:
-  // mist.disableBattery();
+  // (Battery Kit V0.3? Its preset ships with battery sensing off - no ST pin.)
   mist.begin();
   Serial.println("MistBlink: 6 s ON / 3 s OFF");
 }

--- a/examples/MistBlink/MistBlink.ino
+++ b/examples/MistBlink/MistBlink.ino
@@ -12,8 +12,8 @@
 #include <MistMaker.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());

--- a/examples/MistBlink/MistBlink.ino
+++ b/examples/MistBlink/MistBlink.ino
@@ -12,7 +12,8 @@
 #include <MistMaker.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -23,7 +24,9 @@ const unsigned long OFF_TIME_MS = 3000;
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
+  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
+  // can't cause a false low-battery shutdown:
+  // mist.disableBattery();
   mist.begin();
   Serial.println("MistBlink: 6 s ON / 3 s OFF");
 }

--- a/examples/MistBlink/MistBlink.ino
+++ b/examples/MistBlink/MistBlink.ino
@@ -7,7 +7,7 @@
 // preset that matches your PCB below.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 1.1.0
+// Library: MistMaker >= 2.0.0
 
 #include <MistMaker.h>
 

--- a/examples/MistDimming/MistDimming.ino
+++ b/examples/MistDimming/MistDimming.ino
@@ -14,7 +14,8 @@
 #include <math.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -25,7 +26,9 @@ const uint8_t LEVEL_FLOOR = 30;              // don't go fully off mid-breath
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
+  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
+  // can't cause a false low-battery shutdown:
+  // mist.disableBattery();
   mist.begin();
   Serial.println("MistDimming: sine breathing, period 8 s");
 }

--- a/examples/MistDimming/MistDimming.ino
+++ b/examples/MistDimming/MistDimming.ino
@@ -14,8 +14,8 @@
 #include <math.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());

--- a/examples/MistDimming/MistDimming.ino
+++ b/examples/MistDimming/MistDimming.ino
@@ -8,7 +8,7 @@
 // like the Block Kit's wave mode.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 1.1.0
+// Library: MistMaker >= 2.0.0
 
 #include <MistMaker.h>
 #include <math.h>

--- a/examples/MistDimming/MistDimming.ino
+++ b/examples/MistDimming/MistDimming.ino
@@ -15,7 +15,7 @@
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -26,9 +26,7 @@ const uint8_t LEVEL_FLOOR = 30;              // don't go fully off mid-breath
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
-  // can't cause a false low-battery shutdown:
-  // mist.disableBattery();
+  // (Battery Kit V0.3? Its preset ships with battery sensing off - no ST pin.)
   mist.begin();
   Serial.println("MistDimming: sine breathing, period 8 s");
 }

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -33,7 +33,8 @@
 #include <WebSocketsClient.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 
@@ -124,7 +125,9 @@ void onWsEvent(WStype_t type, uint8_t* payload, size_t len) {
 void setup() {
   Serial.begin(115200);
   delay(500);
-  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
+  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
+  // can't cause a false low-battery shutdown:
+  // mist.disableBattery();
   mist.begin();
 
   uint8_t mac[6];

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -64,7 +64,7 @@ const char* waterName(MistSenseState s) {
 
 // level is a 0-100 percentage; the library caps real PWM duty at 50% internally,
 // so 100 here is full mist, not 100% duty.
-void applyLevel(int pct) {
+void applyMistPercent(int pct) {
   pct = constrain(pct, 0, 100);
   if (pct == level) return;                // ignore no-op commands
   level = pct;
@@ -94,12 +94,12 @@ void onCommand(const char* msg) {
               (!strncmp(tgt, deviceId, n) && tgt[n] == '"');  // exact id, not a prefix
     }
     const char* lv = strstr(msg, "\"level\":");
-    if (forMe && lv) { lastCmd = millis(); applyLevel(atoi(lv + 8)); }
+    if (forMe && lv) { lastCmd = millis(); applyMistPercent(atoi(lv + 8)); }
   } else if (strstr(msg, "\"t\":\"multi\"")) {
     char key[10];
     snprintf(key, sizeof(key), "\"%s\":", deviceId);    // find "A4F1":NN
     const char* p = strstr(msg, key);
-    if (p) { lastCmd = millis(); applyLevel(atoi(p + strlen(key))); }
+    if (p) { lastCmd = millis(); applyMistPercent(atoi(p + strlen(key))); }
   }
 }
 
@@ -110,7 +110,7 @@ void onWsEvent(WStype_t type, uint8_t* payload, size_t len) {
       break;
     case WStype_DISCONNECTED:
       Serial.println("[WS] disconnected — mist off, will retry every 3 s");
-      applyLevel(0);                                   // fail-safe: never atomize on a dead link
+      applyMistPercent(0);                                   // fail-safe: never atomize on a dead link
       break;
     case WStype_ERROR:
       Serial.println("[WS] error");
@@ -173,7 +173,7 @@ void loop() {
   // cut the mist rather than atomize forever.
   if (level > 0 && millis() - lastCmd > CMD_TIMEOUT) {
     Serial.println("[WATCHDOG] no commands — mist off");
-    applyLevel(0);
+    applyMistPercent(0);
   }
 
   // Re-probe water/disc every 30 s so the app's status stays live, and never
@@ -181,7 +181,7 @@ void loop() {
   if (millis() - lastProbe > 30000) {
     lastProbe = millis();
     MistSenseState s = mist.probe();
-    if (s == MIST_DISC_MISSING || s == MIST_DISC_DISCONNECTED) applyLevel(0);
+    if (s == MIST_DISC_MISSING || s == MIST_DISC_DISCONNECTED) applyMistPercent(0);
   }
 
   // Once a second: report status to the app AND print a Serial heartbeat.

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -34,7 +34,7 @@
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 
@@ -125,9 +125,7 @@ void onWsEvent(WStype_t type, uint8_t* payload, size_t len) {
 void setup() {
   Serial.begin(115200);
   delay(500);
-  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
-  // can't cause a false low-battery shutdown:
-  // mist.disableBattery();
+  // (Battery Kit V0.3? Its preset ships with battery sensing off - no ST pin.)
   mist.begin();
 
   uint8_t mac[6];

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -25,7 +25,7 @@
 //   2. Fill in WIFI_SSID / WIFI_PASS / RELAY_HOST below.
 //   3. Flash. Open the app URL on your phone. Your maker appears in the list.
 //
-// Library: MistMaker >= 1.1.0  +  "WebSockets" by Markus Sattler (Library Mgr)
+// Library: MistMaker >= 2.0.0  +  "WebSockets" by Markus Sattler (Library Mgr)
 // Board:   Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
 
 #include <MistMaker.h>

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -33,8 +33,8 @@
 #include <WebSocketsClient.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 

--- a/examples/Ramping/Ramping.ino
+++ b/examples/Ramping/Ramping.ino
@@ -24,14 +24,14 @@ void setup() {
 void loop() {
   Serial.println("Ramping up...");
   for (int i = 0; i <= 255; i += 25) {
-    mist.applyLevel(i);
+    mist.setLevel(i);
     Serial.printf("Level: %d\n", i);
     delay(500);
   }
   
   Serial.println("Ramping down...");
   for (int i = 255; i >= 0; i -= 25) {
-    mist.applyLevel(i);
+    mist.setLevel(i);
     Serial.printf("Level: %d\n", i);
     delay(500);
   }

--- a/examples/WaterDetect/WaterDetect.ino
+++ b/examples/WaterDetect/WaterDetect.ino
@@ -22,7 +22,8 @@
 #include <MistMaker.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -51,7 +52,9 @@ const char* stateName(MistSenseState s) {
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  mist.disableBattery();   // V0.3 D1 can't tell USB from battery — re-add at V0.4
+  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
+  // can't cause a false low-battery shutdown:
+  // mist.disableBattery();
   mist.begin();
 
   Serial.println("WaterDetect: 'c' = auto-calibrate (disc attached, in water)");

--- a/examples/WaterDetect/WaterDetect.ino
+++ b/examples/WaterDetect/WaterDetect.ino
@@ -17,7 +17,7 @@
 // the disc is missing or the water runs out; refill/reattach and it resumes.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 1.1.0
+// Library: MistMaker >= 2.0.0
 
 #include <MistMaker.h>
 

--- a/examples/WaterDetect/WaterDetect.ino
+++ b/examples/WaterDetect/WaterDetect.ino
@@ -23,7 +23,7 @@
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -52,9 +52,7 @@ const char* stateName(MistSenseState s) {
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  // On Battery Kit V0.3 (no ST pin) uncomment so the unreliable D1 reading
-  // can't cause a false low-battery shutdown:
-  // mist.disableBattery();
+  // (Battery Kit V0.3? Its preset ships with battery sensing off - no ST pin.)
   mist.begin();
 
   Serial.println("WaterDetect: 'c' = auto-calibrate (disc attached, in water)");

--- a/examples/WaterDetect/WaterDetect.ino
+++ b/examples/WaterDetect/WaterDetect.ino
@@ -22,8 +22,8 @@
 #include <MistMaker.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());

--- a/examples/WiFiPhoneControl/WiFiPhoneControl.ino
+++ b/examples/WiFiPhoneControl/WiFiPhoneControl.ino
@@ -9,21 +9,23 @@
 // Built for workshops and demos: dimming + current-sense water detection over
 // a self-hosted WiFi AP — no app, no router, no internet.
 //
-// NOTE: battery monitoring + low-battery deep-sleep are intentionally OFF on
-// this branch. Battery Kit V0.3 can't tell USB-C power from a real cell on D1,
-// so the reading is unreliable (it caused false brown-out shutdowns), and a
-// board that deep-sleeps is awkward to reflash mid-workshop. TODO(V0.4): re-add
-// battery brown-out + graceful deep-sleep once the board has a USB-present pin.
+// Battery: on Battery Kit V0.4 the TPS2116 mux STATUS pin (D8) lets the library
+// tell USB from the cell, so low-battery deep-sleep is safe again —
+// batteryState() reports CHARGING on USB and only CRITICAL on a dying cell, so
+// the board never sleeps while it's plugged in for reflashing. On V0.3 (no ST
+// pin) switch the preset below and uncomment mist.disableBattery() in setup().
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 1.1.0
+// Library: MistMaker >= 1.2.0
 
 #include <MistMaker.h>
 #include <WiFi.h>
 #include <WebServer.h>
+#include <esp_sleep.h>          // deep sleep on a critically low cell
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV03());
+MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -35,6 +37,7 @@ WebServer server(80);
 
 uint8_t targetLevel = 0;
 unsigned long lastProbe = 0;
+unsigned long lastBattMs = 0;
 bool blocked = false;          // true when sense says we must not mist
 
 // ------------------------------------------------------------------ web UI
@@ -107,10 +110,26 @@ void handleSet() {
   server.send(200, "text/plain", "ok");
 }
 
+// Low-battery guard. batteryState() is ST-gated: it returns MIST_BATT_CHARGING
+// on USB, so this only fires on a genuinely dying cell — never while plugged in
+// to reflash. On CRITICAL: mist off, radio off, deep-sleep to protect the LiPo
+// (recharge + reset/power-cycle wakes it).
+void checkBattery() {
+  if (mist.batteryState() != MIST_BATT_CRITICAL) return;
+  Serial.println("[BATTERY] Critical on cell - graceful shutdown.");
+  mist.shutdown();
+  WiFi.softAPdisconnect(true);
+  WiFi.mode(WIFI_OFF);
+  delay(100);
+  esp_deep_sleep_start();
+}
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
-  mist.disableBattery();   // V0.3: D1 can't tell USB from battery (see note up top)
+  // On Battery Kit V0.3 (no ST pin) uncomment this so the unreliable D1 reading
+  // can't trigger a false low-battery shutdown:
+  // mist.disableBattery();
   mist.begin();
 
   WiFi.mode(WIFI_AP);
@@ -146,5 +165,11 @@ void loop() {
       blocked = false;
       mist.setLevel(targetLevel);
     }
+  }
+
+  // Low-battery guard every 5 s (no-op on USB / boards without a cell).
+  if (millis() - lastBattMs > 5000) {
+    lastBattMs = millis();
+    checkBattery();
   }
 }

--- a/examples/WiFiPhoneControl/WiFiPhoneControl.ino
+++ b/examples/WiFiPhoneControl/WiFiPhoneControl.ino
@@ -16,7 +16,7 @@
 // pin) switch the preset below and uncomment mist.disableBattery() in setup().
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 1.2.0
+// Library: MistMaker >= 2.0.0
 
 #include <MistMaker.h>
 #include <WiFi.h>

--- a/examples/WiFiPhoneControl/WiFiPhoneControl.ino
+++ b/examples/WiFiPhoneControl/WiFiPhoneControl.ino
@@ -13,7 +13,7 @@
 // tell USB from the cell, so low-battery deep-sleep is safe again —
 // batteryState() reports CHARGING on USB and only CRITICAL on a dying cell, so
 // the board never sleeps while it's plugged in for reflashing. On V0.3 (no ST
-// pin) switch the preset below and uncomment mist.disableBattery() in setup().
+// pin) switch the preset below — its preset ships with battery sensing off.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
 // Library: MistMaker >= 2.0.0
@@ -25,7 +25,7 @@
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -134,7 +134,6 @@ void setup() {
   delay(1000);
   // On Battery Kit V0.3 (no ST pin) uncomment this so the unreliable D1 reading
   // can't trigger a false low-battery shutdown:
-  // mist.disableBattery();
   mist.begin();
 
   WiFi.mode(WIFI_AP);

--- a/examples/WiFiPhoneControl/WiFiPhoneControl.ino
+++ b/examples/WiFiPhoneControl/WiFiPhoneControl.ino
@@ -24,8 +24,8 @@
 #include <esp_sleep.h>          // deep sleep on a critically low cell
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // ST on D8 gates battery vs USB
-// MistMaker mist(MistMakerBatteryKitV03()); // V0.3: also uncomment disableBattery() below
+MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+// MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board: use this + uncomment disableBattery() (D8 floats on V0.3)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
 // MistMaker mist(MistMakerLegacyV1());
@@ -115,7 +115,12 @@ void handleSet() {
 // to reflash. On CRITICAL: mist off, radio off, deep-sleep to protect the LiPo
 // (recharge + reset/power-cycle wakes it).
 void checkBattery() {
-  if (mist.batteryState() != MIST_BATT_CRITICAL) return;
+  // Require TWO consecutive CRITICAL reads (~10 s) before the irreversible
+  // deep-sleep. A single sample can lie: the boost sags BATT+ under mist load,
+  // and on a V0.3 board the sense pin floats — neither should strand the board.
+  static uint8_t critStreak = 0;
+  if (mist.batteryState() != MIST_BATT_CRITICAL) { critStreak = 0; return; }
+  if (++critStreak < 2) return;
   Serial.println("[BATTERY] Critical on cell - graceful shutdown.");
   mist.shutdown();
   WiFi.softAPdisconnect(true);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MistMaker
-version=1.2.0
+version=2.0.0
 author=shuang cai, David Yang
 maintainer=shuangcai64@gmail.com
 sentence=A library to control a mist maker under OSHWA ID US002742 with PWM, current sensing, and battery monitoring.

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=MistMaker
-version=1.1.0
+version=1.2.0
 author=shuang cai, David Yang
 maintainer=shuangcai64@gmail.com
 sentence=A library to control a mist maker under OSHWA ID US002742 with PWM, current sensing, and battery monitoring.
-paragraph=Encapsulates mist maker control functions: 108.7kHz PWM with dimming, piezo current sensing with auto/manual calibration, disc and water-level detection, battery voltage monitoring with graceful low-battery shutdown, and pin presets for all official Programmable Mist Maker PCB variants.
+paragraph=Encapsulates mist maker control functions: 108.7kHz PWM with dimming, piezo current sensing with auto/manual calibration, disc and water-level detection, battery voltage monitoring with USB-vs-cell power-source detection (mux status) and graceful low-battery shutdown, and pin presets for all official Programmable Mist Maker PCB variants.
 category=Signal Input/Output
 url=https://github.com/Dav1dyang/Programmable-Mist-Maker
 architectures=esp32

--- a/src/MistMaker.cpp
+++ b/src/MistMaker.cpp
@@ -6,7 +6,7 @@
 MistMaker::MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
                      int pwmFreq, int pwmRes, int duty)
   : _mistPin(mistPin), _enPin(enPin), _sensePin(sensePin), _ledPin(ledPin),
-    _buttonPin(-1), _battPin(-1),
+    _buttonPin(-1), _battPin(-1), _usbSensePin(-1),
     _pwmFreq(pwmFreq), _pwmRes(pwmRes), _dutyCycle(duty),
     _dutyMax(127), _level(0), _state(false), _lastPrintTime(0),
     _senseFactor(3.0f),
@@ -18,8 +18,9 @@ MistMaker::MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
 
 MistMaker::MistMaker(const MistMakerPins &p, int pwmFreq, int pwmRes, int duty)
   : MistMaker(p.mist, p.boostEn, p.sense, p.led, pwmFreq, pwmRes, duty) {
-  _buttonPin = p.button;
-  _battPin   = p.battery;
+  _buttonPin   = p.button;
+  _battPin     = p.battery;
+  _usbSensePin = p.usbSense;
 }
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,9 @@ void MistMaker::begin() {
   if (_sensePin >= 0)  pinMode(_sensePin, INPUT);
   if (_battPin >= 0)   pinMode(_battPin, INPUT);
   if (_buttonPin >= 0) pinMode(_buttonPin, INPUT); // PCB has its own pull-down
+  // Mux ST (TPS2116 pin 8) is level-shifted by an external divider on V0.4, so
+  // read it as a plain high-Z INPUT — an internal pull would swamp the divider.
+  if (_usbSensePin >= 0) pinMode(_usbSensePin, INPUT);
 
   // NOTE: we deliberately do NOT call analogReadResolution() or
   // analogSetPinAttenuation() — on ESP32-C6 + arduino-esp32 v3.x those calls
@@ -210,9 +214,13 @@ void MistMaker::setBatteryThresholds(float lowV, float criticalV) {
 float MistMaker::readBatteryVolts(uint8_t samples) {
   if (_battPin < 0) return 0.0f;
   if (samples == 0) samples = 1;
-  uint32_t sum = 0;
-  for (uint8_t i = 0; i < samples; i++) sum += analogRead(_battPin);
-  const float pinV = (float(sum) / samples) * 3.3f / 4095.0f;
+  // analogReadMilliVolts() applies the chip's factory eFuse ADC calibration —
+  // linear millivolts even on ESP32-C6, where raw analogRead() is nonlinear
+  // (arduino-esp32 #11324). It does NOT need analogReadResolution() (the call
+  // we avoid on C6 v3.x), so this stays compatible with begin()'s note.
+  uint32_t sum_mV = 0;
+  for (uint8_t i = 0; i < samples; i++) sum_mV += analogReadMilliVolts(_battPin);
+  const float pinV = (float(sum_mV) / samples) / 1000.0f;
   return pinV * _battDivider;
 }
 
@@ -227,8 +235,25 @@ uint8_t MistMaker::batteryPercent() {
   return (uint8_t)(pct + 0.5f);
 }
 
+bool MistMaker::usbPresent() {
+  // ST HIGH = mux sourcing VIN1 (USB), LOW = VIN2 (cell). See TPS2116 §7.3.3.
+  // No sense pin -> assume USB present (fail safe: don't blind-shutdown).
+  if (_usbSensePin < 0) return true;
+  return digitalRead(_usbSensePin) == HIGH;
+}
+
 MistBatteryState MistMaker::batteryState() {
   if (_battPin < 0) return MIST_BATT_UNKNOWN;
+
+  // Gate on the power mux: with a USB-sense pin wired (V0.4), a HIGH ST means
+  // the load runs from USB and the cell is a charge target — its voltage
+  // tracks the charger, not state-of-charge. Report CHARGING and never
+  // LOW/CRITICAL. This is the fix for the V0.3 false brown-out on USB.
+  if (_usbSensePin >= 0 && usbPresent()) {
+    _battState = MIST_BATT_CHARGING;
+    return _battState;
+  }
+
   const float v = readBatteryVolts();
   // 50 mV hysteresis so we don't flap when the mist load sags the rail.
   switch (_battState) {
@@ -239,7 +264,7 @@ MistBatteryState MistMaker::batteryState() {
       if (v <= _battCritV)            _battState = MIST_BATT_CRITICAL;
       else if (v > _battLowV + 0.05f) _battState = MIST_BATT_OK;
       break;
-    default: // OK or UNKNOWN
+    default: // OK, UNKNOWN, or returning from CHARGING — classify fresh
       if (v <= _battCritV)      _battState = MIST_BATT_CRITICAL;
       else if (v <= _battLowV)  _battState = MIST_BATT_LOW;
       else                      _battState = MIST_BATT_OK;
@@ -275,9 +300,14 @@ void MistMaker::printStatus() {
   if (_battPin >= 0) {
     Serial.print(F(". Battery: "));
     Serial.print(readBatteryVolts(), 2);
-    Serial.print(F(" V ("));
-    Serial.print(batteryPercent());
-    Serial.print(F("%)"));
+    Serial.print(F(" V"));
+    if (_usbSensePin >= 0 && usbPresent()) {
+      Serial.print(F(" (USB charging)"));
+    } else {
+      Serial.print(F(" ("));
+      Serial.print(batteryPercent());
+      Serial.print(F("%)"));
+    }
   }
   Serial.println();
 

--- a/src/MistMaker.cpp
+++ b/src/MistMaker.cpp
@@ -38,7 +38,7 @@ MistMaker::MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
                      uint32_t pwmFreq, uint8_t pwmRes, int dutyMax)
   : _mistPin(mistPin), _enPin(enPin), _sensePin(sensePin), _ledPin(ledPin),
     _buttonPin(-1), _battPin(-1), _usbSensePin(-1),
-    _pwmFreq(pwmFreq), _pwmRes(pwmRes == 0 ? 1 : pwmRes),
+    _pwmFreq(pwmFreq), _pwmRes(pwmRes < 1 ? 1 : (pwmRes > 16 ? 16 : pwmRes)),
     // _pwmRes is initialized above (declaration order), so this is safe:
     _dutyMax(resolveDutyCap(dutyMax)), _level(0), _state(false), _startTime(0),
     _senseFactor(MistMakerDefaults::SENSE_VOLTS_PER_AMP),
@@ -63,10 +63,15 @@ MistMaker::MistMaker(const MistMakerPins &p,
 
 uint16_t MistMaker::resolveDutyCap(int requested) const {
   const uint16_t fullScale = (uint16_t)((1u << _pwmRes) - 1u);
-  if (requested >= 1 && requested <= (int)fullScale) return (uint16_t)requested;
-  // DUTY_AUTO, 0, negatives, or beyond full scale (incl. values 1.x ignored):
-  // 50% of full scale — the efficiency/stability knee (127 at 8-bit).
-  return (uint16_t)(fullScale / 2);
+  // ~90% of full scale is the physical ceiling: above it the resonant
+  // ring-back has no time to swing, so the drive makes heat, not mist
+  // (bench sweep, 2026-07-03). Requests beyond it clamp to the ceiling.
+  const uint16_t ceiling = (uint16_t)(((uint32_t)fullScale * 9u) / 10u);
+  if (requested >= 1 && requested <= (int)ceiling) return (uint16_t)requested;
+  if (requested > (int)ceiling) return ceiling;
+  // DUTY_AUTO, 0, or negatives: 50% of full scale — the efficiency knee.
+  const uint16_t half = (uint16_t)(fullScale / 2);
+  return half < 1 ? 1 : half;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/MistMaker.cpp
+++ b/src/MistMaker.cpp
@@ -22,17 +22,25 @@ namespace {
   // counts for current sense; battery uses analogReadMilliVolts (calibrated).
   constexpr float ADC_FULL_SCALE_V = 3.3f;
   constexpr float ADC_MAX_COUNT    = 4095.0f;
+
+  // printStatus() uses a shorter averaging window than a real measurement —
+  // it's a glance, not a reading.
+  constexpr uint16_t STATUS_SAMPLE_MS = 20;
+
+  // Below any plausible cell voltage -> battery pin floating / not connected.
+  constexpr float BATT_ABSENT_V = 0.5f;
 }
 
 // ---------------------------------------------------------------------------
 // Constructors
 // ---------------------------------------------------------------------------
 MistMaker::MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
-                     uint32_t pwmFreq, uint8_t pwmRes, uint8_t dutyMax)
+                     uint32_t pwmFreq, uint8_t pwmRes, int dutyMax)
   : _mistPin(mistPin), _enPin(enPin), _sensePin(sensePin), _ledPin(ledPin),
     _buttonPin(-1), _battPin(-1), _usbSensePin(-1),
-    _pwmFreq(pwmFreq), _pwmRes(pwmRes),
-    _dutyMax(dutyMax), _level(0), _state(false), _startTime(0),
+    _pwmFreq(pwmFreq), _pwmRes(pwmRes == 0 ? 1 : pwmRes),
+    // _pwmRes is initialized above (declaration order), so this is safe:
+    _dutyMax(resolveDutyCap(dutyMax)), _level(0), _state(false), _startTime(0),
     _senseFactor(MistMakerDefaults::SENSE_VOLTS_PER_AMP),
     _thDiscPresentMa(MistMakerDefaults::TH_DISC_PRESENT_MA),
     _thWaterLowMa(MistMakerDefaults::TH_WATER_LOW_MA),
@@ -46,11 +54,19 @@ MistMaker::MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
     _battState(MIST_BATT_UNKNOWN) {}
 
 MistMaker::MistMaker(const MistMakerPins &p,
-                     uint32_t pwmFreq, uint8_t pwmRes, uint8_t dutyMax)
+                     uint32_t pwmFreq, uint8_t pwmRes, int dutyMax)
   : MistMaker(p.mist, p.boostEn, p.sense, p.led, pwmFreq, pwmRes, dutyMax) {
   _buttonPin   = p.button;
   _battPin     = p.battery;
   _usbSensePin = p.usbSense;
+}
+
+uint16_t MistMaker::resolveDutyCap(int requested) const {
+  const uint16_t fullScale = (uint16_t)((1u << _pwmRes) - 1u);
+  if (requested >= 1 && requested <= (int)fullScale) return (uint16_t)requested;
+  // DUTY_AUTO, 0, negatives, or beyond full scale (incl. values 1.x ignored):
+  // 50% of full scale — the resonant sweet spot (127 at 8-bit).
+  return (uint16_t)(fullScale / 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -81,7 +97,7 @@ void MistMaker::begin() {
 // ---------------------------------------------------------------------------
 // Basic control
 // ---------------------------------------------------------------------------
-void MistMaker::applyDuty(uint8_t duty) {
+void MistMaker::applyDuty(uint16_t duty) {
   ledcWrite(_mistPin, duty);
 }
 
@@ -115,8 +131,8 @@ void MistMaker::setLevel(uint8_t level) {
   if (level == 0) { turnOff(); return; }
   if (_enPin >= 0) digitalWrite(_enPin, HIGH);
   if (_ledPin >= 0) digitalWrite(_ledPin, HIGH);
-  // 1..255 -> 1.._dutyMax, rounding so level 255 lands exactly on dutyMax.
-  uint8_t duty = (uint8_t)(((uint16_t)level * _dutyMax + 127) / 255);
+  // 1..255 -> 1.._dutyMax; + 255/2 rounds half-up so 255 lands on dutyMax.
+  uint16_t duty = (uint16_t)(((uint32_t)level * _dutyMax + (255 / 2)) / 255);
   if (duty == 0) duty = 1;
   applyDuty(duty);
   _state = true;
@@ -148,7 +164,7 @@ void MistMaker::setSenseThresholds(float discPresentMa, float waterLowMa,
 // Drive at `duty` for settleMs, average current for sampleMs, then restore
 // whatever the mist was doing before. The boost rail is held on during the
 // probe so back-to-back probes don't churn the converter.
-float MistMaker::probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs) {
+float MistMaker::probeAtDuty(uint16_t duty, uint16_t settleMs, uint16_t sampleMs) {
   if (_sensePin < 0) return 0.0f;
   const bool boostWasOff = (_enPin >= 0) && (digitalRead(_enPin) == LOW);
   if (boostWasOff) { digitalWrite(_enPin, HIGH); delay(BOOST_SOFTSTART_MS); }
@@ -250,12 +266,10 @@ uint8_t MistMaker::batteryPercent() {
   // Rough open-ish-circuit LiPo curve, clamped EMPTY..FULL. Good enough for
   // a UI gauge; don't use it for cutoff decisions (use batteryState()).
   const float v = readBatteryVolts();
-  if (v <= 0.5f) return 0; // no battery pin / not connected
-  float pct = (v - MistMakerDefaults::BATT_EMPTY_V) /
+  if (v <= BATT_ABSENT_V) return 0; // no battery pin / not connected
+  const float pct = (v - MistMakerDefaults::BATT_EMPTY_V) /
               (MistMakerDefaults::BATT_FULL_V - MistMakerDefaults::BATT_EMPTY_V) * 100.0f;
-  if (pct < 0.0f) pct = 0.0f;
-  if (pct > 100.0f) pct = 100.0f;
-  return (uint8_t)(pct + 0.5f);
+  return (uint8_t)(constrain(pct, 0.0f, 100.0f) + 0.5f); // round half-up
 }
 
 bool MistMaker::usbPresent() {
@@ -321,7 +335,7 @@ void MistMaker::printStatus() {
 
   if (_sensePin >= 0) {
     Serial.print(F(". Current: "));
-    Serial.print(readCurrentMa(20), 1);
+    Serial.print(readCurrentMa(STATUS_SAMPLE_MS), 1);
     Serial.print(F(" mA"));
   }
   if (_battPin >= 0) {

--- a/src/MistMaker.cpp
+++ b/src/MistMaker.cpp
@@ -65,7 +65,7 @@ uint16_t MistMaker::resolveDutyCap(int requested) const {
   const uint16_t fullScale = (uint16_t)((1u << _pwmRes) - 1u);
   if (requested >= 1 && requested <= (int)fullScale) return (uint16_t)requested;
   // DUTY_AUTO, 0, negatives, or beyond full scale (incl. values 1.x ignored):
-  // 50% of full scale — the resonant sweet spot (127 at 8-bit).
+  // 50% of full scale — the efficiency/stability knee (127 at 8-bit).
   return (uint16_t)(fullScale / 2);
 }
 

--- a/src/MistMaker.cpp
+++ b/src/MistMaker.cpp
@@ -250,8 +250,11 @@ MistBatteryState MistMaker::batteryState() {
   // tracks the charger, not state-of-charge. Report CHARGING and never
   // LOW/CRITICAL. This is the fix for the V0.3 false brown-out on USB.
   if (_usbSensePin >= 0 && usbPresent()) {
-    _battState = MIST_BATT_CHARGING;
-    return _battState;
+    // Report CHARGING but do NOT overwrite _battState: a transient ST HIGH (mux
+    // chatter, or a floating pin on a V0.3 board) must not wipe the LOW/CRITICAL
+    // hysteresis latch, or a cell sitting right at the threshold gets released
+    // early when we drop back to it. The latch resumes untouched on the cell.
+    return MIST_BATT_CHARGING;
   }
 
   const float v = readBatteryVolts();
@@ -264,7 +267,7 @@ MistBatteryState MistMaker::batteryState() {
       if (v <= _battCritV)            _battState = MIST_BATT_CRITICAL;
       else if (v > _battLowV + 0.05f) _battState = MIST_BATT_OK;
       break;
-    default: // OK, UNKNOWN, or returning from CHARGING — classify fresh
+    default: // OK or UNKNOWN — classify fresh (CHARGING never latches here)
       if (v <= _battCritV)      _battState = MIST_BATT_CRITICAL;
       else if (v <= _battLowV)  _battState = MIST_BATT_LOW;
       else                      _battState = MIST_BATT_OK;

--- a/src/MistMaker.cpp
+++ b/src/MistMaker.cpp
@@ -1,23 +1,53 @@
 #include "MistMaker.h"
 
+namespace {
+  // Probe choreography (ms). Settle = let the drive + water column respond
+  // before measuring; sample = averaging window. Calibration settles longer
+  // because its numbers get baked into thresholds.
+  constexpr uint16_t PRESENCE_SETTLE_MS = 50,  PRESENCE_SAMPLE_MS = 100;
+  constexpr uint16_t WATER_SETTLE_MS    = 80,  WATER_SAMPLE_MS    = 150;
+  constexpr uint16_t CAL_LOW_SETTLE_MS  = 100, CAL_LOW_SAMPLE_MS  = 200;
+  constexpr uint16_t CAL_WET_SETTLE_MS  = 150, CAL_WET_SAMPLE_MS  = 300;
+  constexpr uint16_t BOOST_SOFTSTART_MS = 20;
+
+  // autoCalibrateSense(): thresholds as fractions of the wet references,
+  // and minimum plausible wet readings (mA) below which we refuse to
+  // calibrate (disc missing/dry would bake in garbage).
+  constexpr float CAL_PRESENT_FRACTION = 0.50f;  // of wet low-duty reading
+  constexpr float CAL_WATERLOW_FRACTION = 0.75f; // of wet working-duty reading
+  constexpr float CAL_DISCONN_FRACTION  = 0.50f; // of wet working-duty reading
+  constexpr float CAL_MIN_LOW_MA = 2.0f, CAL_MIN_WET_MA = 20.0f;
+
+  // ESP32 Arduino core ADC defaults (12-bit, ~3.3 V full scale). We read raw
+  // counts for current sense; battery uses analogReadMilliVolts (calibrated).
+  constexpr float ADC_FULL_SCALE_V = 3.3f;
+  constexpr float ADC_MAX_COUNT    = 4095.0f;
+}
+
 // ---------------------------------------------------------------------------
 // Constructors
 // ---------------------------------------------------------------------------
 MistMaker::MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
-                     int pwmFreq, int pwmRes, int duty)
+                     uint32_t pwmFreq, uint8_t pwmRes, uint8_t dutyMax)
   : _mistPin(mistPin), _enPin(enPin), _sensePin(sensePin), _ledPin(ledPin),
     _buttonPin(-1), _battPin(-1), _usbSensePin(-1),
-    _pwmFreq(pwmFreq), _pwmRes(pwmRes), _dutyCycle(duty),
-    _dutyMax(127), _level(0), _state(false), _lastPrintTime(0),
-    _senseFactor(3.0f),
-    _thDiscPresentMa(10.0f), _thWaterLowMa(110.0f), _thDiscDisconnMa(70.0f),
-    _probeDuty(10), _waterProbeDuty(64),
+    _pwmFreq(pwmFreq), _pwmRes(pwmRes),
+    _dutyMax(dutyMax), _level(0), _state(false), _startTime(0),
+    _senseFactor(MistMakerDefaults::SENSE_VOLTS_PER_AMP),
+    _thDiscPresentMa(MistMakerDefaults::TH_DISC_PRESENT_MA),
+    _thWaterLowMa(MistMakerDefaults::TH_WATER_LOW_MA),
+    _thDiscDisconnMa(MistMakerDefaults::TH_DISC_DISCONN_MA),
+    _probeDuty(MistMakerDefaults::PROBE_DUTY),
+    _waterProbeDuty(MistMakerDefaults::WATER_PROBE_DUTY),
     _senseState(MIST_SENSE_UNKNOWN), _lastProbeMa(0.0f),
-    _battDivider(2.0f), _battLowV(3.45f), _battCritV(3.20f),
+    _battDivider(MistMakerDefaults::BATT_DIVIDER),
+    _battLowV(MistMakerDefaults::BATT_LOW_V),
+    _battCritV(MistMakerDefaults::BATT_CRITICAL_V),
     _battState(MIST_BATT_UNKNOWN) {}
 
-MistMaker::MistMaker(const MistMakerPins &p, int pwmFreq, int pwmRes, int duty)
-  : MistMaker(p.mist, p.boostEn, p.sense, p.led, pwmFreq, pwmRes, duty) {
+MistMaker::MistMaker(const MistMakerPins &p,
+                     uint32_t pwmFreq, uint8_t pwmRes, uint8_t dutyMax)
+  : MistMaker(p.mist, p.boostEn, p.sense, p.led, pwmFreq, pwmRes, dutyMax) {
   _buttonPin   = p.button;
   _battPin     = p.battery;
   _usbSensePin = p.usbSense;
@@ -67,7 +97,7 @@ void MistMaker::turnOff() {
   if (_enPin >= 0) digitalWrite(_enPin, LOW);
   if (_ledPin >= 0) digitalWrite(_ledPin, LOW);
   applyDuty(0);
-  digitalWrite(_mistPin, LOW);
+  digitalWrite(_mistPin, LOW);  // safety belt if the pin ever leaves LEDC
   _level = 0;
   _state = false;
 }
@@ -95,12 +125,6 @@ void MistMaker::setLevel(uint8_t level) {
 // ---------------------------------------------------------------------------
 // Current sensing
 // ---------------------------------------------------------------------------
-float MistMaker::readCurrentVoltage() {
-  // v1.0 compat: raw sense-pin voltage with the original 2x scale.
-  if (_sensePin < 0) return 0.0f;
-  return (analogRead(_sensePin) / 4095.0f) * 3.3f * 2.0f;
-}
-
 float MistMaker::readCurrentMa(uint16_t sampleMs) {
   if (_sensePin < 0) return 0.0f;
   uint32_t sum = 0, n = 0;
@@ -110,7 +134,7 @@ float MistMaker::readCurrentMa(uint16_t sampleMs) {
     n++;
   }
   if (n == 0) return 0.0f;
-  const float volts = (float(sum) / float(n)) * 3.3f / 4095.0f;
+  const float volts = (float(sum) / float(n)) * ADC_FULL_SCALE_V / ADC_MAX_COUNT;
   return volts * 1000.0f / _senseFactor;
 }
 
@@ -127,7 +151,7 @@ void MistMaker::setSenseThresholds(float discPresentMa, float waterLowMa,
 float MistMaker::probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs) {
   if (_sensePin < 0) return 0.0f;
   const bool boostWasOff = (_enPin >= 0) && (digitalRead(_enPin) == LOW);
-  if (boostWasOff) { digitalWrite(_enPin, HIGH); delay(20); } // rail soft-start
+  if (boostWasOff) { digitalWrite(_enPin, HIGH); delay(BOOST_SOFTSTART_MS); }
 
   applyDuty(duty);
   delay(settleMs);
@@ -143,7 +167,7 @@ float MistMaker::probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs)
 }
 
 bool MistMaker::discPresent() {
-  const float ma = probeAtDuty(_probeDuty, 50, 100);
+  const float ma = probeAtDuty(_probeDuty, PRESENCE_SETTLE_MS, PRESENCE_SAMPLE_MS);
   _lastProbeMa = ma;
   const bool present = ma >= _thDiscPresentMa;
   if (!present) _senseState = MIST_DISC_MISSING;
@@ -157,7 +181,7 @@ MistSenseState MistMaker::probe() {
   if (!discPresent()) return _senseState; // MIST_DISC_MISSING
 
   // Step 2: water probe at working duty.
-  const float ma = probeAtDuty(_waterProbeDuty, 80, 150);
+  const float ma = probeAtDuty(_waterProbeDuty, WATER_SETTLE_MS, WATER_SAMPLE_MS);
   _lastProbeMa = ma;
   if (ma < _thDiscDisconnMa)      _senseState = MIST_DISC_DISCONNECTED;
   else if (ma < _thWaterLowMa)    _senseState = MIST_WATER_LOW;
@@ -172,8 +196,8 @@ bool MistMaker::autoCalibrateSense() {
   Serial.println(F("[MistMaker] Auto-calibrating current sense."));
   Serial.println(F("[MistMaker] Disc must be attached and sitting in water!"));
 
-  const float lowMa   = probeAtDuty(_probeDuty, 100, 200);      // presence ref
-  const float waterMa = probeAtDuty(_waterProbeDuty, 150, 300); // wet ref
+  const float lowMa   = probeAtDuty(_probeDuty, CAL_LOW_SETTLE_MS, CAL_LOW_SAMPLE_MS);
+  const float waterMa = probeAtDuty(_waterProbeDuty, CAL_WET_SETTLE_MS, CAL_WET_SAMPLE_MS);
 
   Serial.print(F("[MistMaker] probe duty "));  Serial.print(_probeDuty);
   Serial.print(F(" -> "));  Serial.print(lowMa, 1);  Serial.println(F(" mA"));
@@ -183,16 +207,14 @@ bool MistMaker::autoCalibrateSense() {
   // Plausibility: a real disc in water draws clearly measurable current at
   // both duties. If not, the disc is missing/dry and calibration would only
   // bake in garbage thresholds.
-  if (lowMa < 2.0f || waterMa < 20.0f || waterMa <= lowMa) {
+  if (lowMa < CAL_MIN_LOW_MA || waterMa < CAL_MIN_WET_MA || waterMa <= lowMa) {
     Serial.println(F("[MistMaker] Calibration FAILED - check disc and water."));
     return false;
   }
 
-  // Thresholds sit between the populated reading and zero/dry territory:
-  //   disc present  = 50% of the wet low-duty reading
-  //   water low     = 75% of the wet working-duty reading
-  //   disconnected  = 50% of the wet working-duty reading
-  setSenseThresholds(lowMa * 0.50f, waterMa * 0.75f, waterMa * 0.50f);
+  setSenseThresholds(lowMa   * CAL_PRESENT_FRACTION,
+                     waterMa * CAL_WATERLOW_FRACTION,
+                     waterMa * CAL_DISCONN_FRACTION);
 
   Serial.println(F("[MistMaker] Calibrated thresholds (mA):"));
   Serial.print(F("  discPresent = ")); Serial.println(_thDiscPresentMa, 1);
@@ -204,7 +226,7 @@ bool MistMaker::autoCalibrateSense() {
 }
 
 // ---------------------------------------------------------------------------
-// Battery
+// Battery + power source
 // ---------------------------------------------------------------------------
 void MistMaker::setBatteryThresholds(float lowV, float criticalV) {
   _battLowV  = lowV;
@@ -225,11 +247,12 @@ float MistMaker::readBatteryVolts(uint8_t samples) {
 }
 
 uint8_t MistMaker::batteryPercent() {
-  // Rough open-ish-circuit LiPo curve, clamped 3.3-4.2 V. Good enough for a
-  // UI gauge; don't use it for cutoff decisions (use batteryState()).
+  // Rough open-ish-circuit LiPo curve, clamped EMPTY..FULL. Good enough for
+  // a UI gauge; don't use it for cutoff decisions (use batteryState()).
   const float v = readBatteryVolts();
   if (v <= 0.5f) return 0; // no battery pin / not connected
-  float pct = (v - 3.30f) / (4.20f - 3.30f) * 100.0f;
+  float pct = (v - MistMakerDefaults::BATT_EMPTY_V) /
+              (MistMakerDefaults::BATT_FULL_V - MistMakerDefaults::BATT_EMPTY_V) * 100.0f;
   if (pct < 0.0f) pct = 0.0f;
   if (pct > 100.0f) pct = 100.0f;
   return (uint8_t)(pct + 0.5f);
@@ -258,14 +281,15 @@ MistBatteryState MistMaker::batteryState() {
   }
 
   const float v = readBatteryVolts();
-  // 50 mV hysteresis so we don't flap when the mist load sags the rail.
+  // Hysteresis so we don't flap when the mist load sags the rail.
+  const float hyst = MistMakerDefaults::BATT_HYST_V;
   switch (_battState) {
     case MIST_BATT_CRITICAL:
-      if (v > _battCritV + 0.05f) _battState = MIST_BATT_LOW;
+      if (v > _battCritV + hyst) _battState = MIST_BATT_LOW;
       break;
     case MIST_BATT_LOW:
-      if (v <= _battCritV)            _battState = MIST_BATT_CRITICAL;
-      else if (v > _battLowV + 0.05f) _battState = MIST_BATT_OK;
+      if (v <= _battCritV)          _battState = MIST_BATT_CRITICAL;
+      else if (v > _battLowV + hyst) _battState = MIST_BATT_OK;
       break;
     default: // OK or UNKNOWN — classify fresh (CHARGING never latches here)
       if (v <= _battCritV)      _battState = MIST_BATT_CRITICAL;
@@ -313,6 +337,4 @@ void MistMaker::printStatus() {
     }
   }
   Serial.println();
-
-  _lastPrintTime = millis();
 }

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -53,6 +53,12 @@ namespace MistMakerDefaults {
   constexpr uint32_t PWM_FREQ_HZ  = 108700;
   constexpr uint8_t  PWM_RES_BITS = 8;
   constexpr int      DUTY_AUTO    = 0;
+  // Bench-measured true mist maximum (~70% duty, V0.4 sweep 2026-07-03):
+  //   mist.setMaxDuty(MistMakerDefaults::DUTY_TURBO);
+  // Costs ~4x the input power of the default cap and needs a strong 5 V
+  // supply (>= 2 A wall adapter); on a battery expect the low-voltage
+  // cutoff within seconds. Above it mist gets weaker and unstable.
+  constexpr int      DUTY_TURBO   = 178;
 
   // Current sense: V per A = amp gain x shunt = INA180A3 (100 V/V) x 30 mOhm.
   constexpr float SENSE_VOLTS_PER_AMP = 3.0f;

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -15,10 +15,10 @@
 //   * hardware tuning values are named constants in MistMakerDefaults (below);
 //     probe/calibration timing lives at the top of MistMaker.cpp
 //   * the constructor's duty-cap parameter now actually takes effect (it was
-//     silently ignored in 1.x). Valid caps are 1..(2^pwmRes - 1); anything
-//     else — including the default DUTY_AUTO — resolves to 50% of full scale
-//     (= 127 at 8-bit, the 1.x behavior), so legacy garbage values can't
-//     wrap into a wrong drive level.
+//     silently ignored in 1.x). Valid caps are 1..90% of full scale; higher
+//     requests clamp to 90% (above it the drive makes heat, not mist —
+//     bench-measured); zero/negative/DUTY_AUTO resolve to 50% of full scale
+//     (= 127 at 8-bit, the 1.x behavior).
 //   * removed: applyLevel() alias -> use setLevel();
 //              readCurrentVoltage() -> use readCurrentMa() (NOTE: different
 //              unit — see README migration note)
@@ -110,11 +110,13 @@ inline MistMakerPins MistMakerExtensionV01() {
   return MistMakerPins{ D0, -1, D2, -1, -1, -1, -1 };
 }
 
-// Mist Maker Battery Kit V0.3 — LiPo + USB-C, battery divider on D1.
-// No mux-status pin: on V0.3 the TPS2116 ST line isn't routed to the XIAO,
-// so battery reads can't tell USB from the cell — call disableBattery().
+// Mist Maker Battery Kit V0.3 — LiPo + USB-C. Battery sensing is OFF in this
+// preset: V0.3 has no mux-status pin, so the D1 divider can't tell USB from
+// the cell and blind reads caused false low-battery shutdowns. To experiment
+// anyway: pins.battery = D1 after construction (readings valid only with USB
+// physically unplugged).
 inline MistMakerPins MistMakerBatteryKitV03() {
-  return MistMakerPins{ D0, D3, D2, D7, D6, D1, -1 };
+  return MistMakerPins{ D0, D3, D2, D7, D6, -1, -1 };
 }
 
 // Mist Maker Battery Kit V0.4 — V0.3 plus the TPS2116 ST (power-mux status)
@@ -183,8 +185,12 @@ public:
   // level 0..255 maps linearly onto 0..dutyMax. 0 = off.
   void setLevel(uint8_t level);
   uint8_t getLevel() const { return _level; }
-  // Same validity policy as the constructor: out-of-range -> 50% auto.
-  void setMaxDuty(int dutyMax) { _dutyMax = resolveDutyCap(dutyMax); }
+  // Same validity policy as the constructor (1..90% of full scale; higher
+  // clamps to 90%; <=0 -> 50% auto). Takes effect immediately, even mid-mist.
+  void setMaxDuty(int dutyMax) {
+    _dutyMax = resolveDutyCap(dutyMax);
+    if (_state && _level > 0) setLevel(_level);   // re-apply at the new cap
+  }
 
   // ------------------- current sensing -------------------
   // Sense-amp transfer factor in V per A (gain x shunt). Change if your
@@ -208,6 +214,9 @@ public:
   // Probe = briefly drive the disc at a probe duty, measure current,
   // classify, then restore whatever the mist was doing before. Blocking
   // for a few hundred ms — schedule probes in an OFF window, not per-loop.
+  // Probe duties are fixed (PROBE_DUTY/WATER_PROBE_DUTY) and deliberately
+  // independent of setMaxDuty(): the classifier thresholds are calibrated
+  // at these exact duties.
   MistSenseState probe();                 // full classify (disc + water)
   bool discPresent();                     // quick low-duty presence check
   MistSenseState senseState() const { return _senseState; }

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -12,11 +12,16 @@
 //   void setup() { mist.begin(); mist.setLevel(180); }
 //
 // v2.0 — cleanup release:
-//   * every tuning value is a named constant in MistMakerDefaults (below)
-//   * constructor `duty` parameter now actually sets the duty cap (it was
-//     silently ignored in 1.x)
+//   * hardware tuning values are named constants in MistMakerDefaults (below);
+//     probe/calibration timing lives at the top of MistMaker.cpp
+//   * the constructor's duty-cap parameter now actually takes effect (it was
+//     silently ignored in 1.x). Valid caps are 1..(2^pwmRes - 1); anything
+//     else — including the default DUTY_AUTO — resolves to 50% of full scale
+//     (= 127 at 8-bit, the 1.x behavior), so legacy garbage values can't
+//     wrap into a wrong drive level.
 //   * removed: applyLevel() alias -> use setLevel();
-//              readCurrentVoltage() -> use readCurrentMa()
+//              readCurrentVoltage() -> use readCurrentMa() (NOTE: different
+//              unit — see README migration note)
 // v1.2   Power-source sensing via the TPS2116 mux ST pin (Battery Kit V0.4):
 //        battery monitoring self-gates on USB-vs-cell, can't false-brown-out.
 // v1.1   Board presets, dimming, current sensing in mA, disc/water detection,
@@ -36,14 +41,17 @@
 // on different hardware.
 // ---------------------------------------------------------------------------
 namespace MistMakerDefaults {
-  // Piezo drive. 108.7 kHz = disc resonance; 8-bit duty; cap at 127 (50%)
-  // because beyond 50% the resonant push-pull gets weaker, not stronger.
+  // Piezo drive. 108.7 kHz = disc resonance. The duty cap defaults to 50% of
+  // full scale (127 at 8-bit) because beyond 50% the resonant push-pull gets
+  // weaker, not stronger. DUTY_AUTO = "resolve to that 50% for whatever
+  // resolution is configured"; any out-of-range cap resolves the same way.
   constexpr uint32_t PWM_FREQ_HZ  = 108700;
   constexpr uint8_t  PWM_RES_BITS = 8;
-  constexpr uint8_t  DUTY_MAX     = 127;
+  constexpr int      DUTY_AUTO    = 0;
 
   // Current sense: V per A = amp gain x shunt = INA180A3 (100 V/V) x 30 mOhm.
   constexpr float SENSE_VOLTS_PER_AMP = 3.0f;
+  constexpr uint16_t SENSE_SAMPLE_MS  = 50;   // default readCurrentMa() window
 
   // Classifier thresholds (mA) — see autoCalibrateSense() for their meaning.
   constexpr float TH_DISC_PRESENT_MA = 10.0f;   // >= this at probe duty -> disc there
@@ -137,17 +145,18 @@ enum MistBatteryState : uint8_t {
 class MistMaker {
 public:
   // Pin-preset constructor (preferred). `dutyMax` caps the PWM duty that
-  // setLevel(255)/turnOn() reach — see MistMakerDefaults::DUTY_MAX.
+  // setLevel(255)/turnOn() reach. Valid range 1..(2^pwmRes - 1); anything
+  // else (including DUTY_AUTO) = 50% of full scale, the resonant sweet spot.
   MistMaker(const MistMakerPins &pins,
             uint32_t pwmFreq = MistMakerDefaults::PWM_FREQ_HZ,
             uint8_t  pwmRes  = MistMakerDefaults::PWM_RES_BITS,
-            uint8_t  dutyMax = MistMakerDefaults::DUTY_MAX);
+            int      dutyMax = MistMakerDefaults::DUTY_AUTO);
 
   // Bare-pins constructor for breadboards / custom wiring (v1.0 signature).
   MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
             uint32_t pwmFreq = MistMakerDefaults::PWM_FREQ_HZ,
             uint8_t  pwmRes  = MistMakerDefaults::PWM_RES_BITS,
-            uint8_t  dutyMax = MistMakerDefaults::DUTY_MAX);
+            int      dutyMax = MistMakerDefaults::DUTY_AUTO);
 
   void begin();
 
@@ -162,14 +171,15 @@ public:
   // level 0..255 maps linearly onto 0..dutyMax. 0 = off.
   void setLevel(uint8_t level);
   uint8_t getLevel() const { return _level; }
-  void setMaxDuty(uint8_t dutyMax) { _dutyMax = dutyMax; }
+  // Same validity policy as the constructor: out-of-range -> 50% auto.
+  void setMaxDuty(int dutyMax) { _dutyMax = resolveDutyCap(dutyMax); }
 
   // ------------------- current sensing -------------------
   // Sense-amp transfer factor in V per A (gain x shunt). Change if your
   // build differs from MistMakerDefaults::SENSE_VOLTS_PER_AMP.
   void setCurrentSenseFactor(float voltsPerAmp) { _senseFactor = voltsPerAmp; }
   // Mean current over `sampleMs` of continuous ADC reads, in mA. Blocking.
-  float readCurrentMa(uint16_t sampleMs = 50);
+  float readCurrentMa(uint16_t sampleMs = MistMakerDefaults::SENSE_SAMPLE_MS);
 
   // Manual thresholds (mA). See autoCalibrateSense() for what they mean.
   void setSenseThresholds(float discPresentMa, float waterLowMa,
@@ -239,13 +249,16 @@ public:
   void shutdown();
 
 private:
-  float probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs);
-  void applyDuty(uint8_t duty);
+  float probeAtDuty(uint16_t duty, uint16_t settleMs, uint16_t sampleMs);
+  void applyDuty(uint16_t duty);
+  // Clamp a requested duty cap to 1..(2^pwmRes - 1); out-of-range (incl.
+  // DUTY_AUTO and 1.x-era ignored values) -> 50% of full scale.
+  uint16_t resolveDutyCap(int requested) const;
 
   int8_t _mistPin, _enPin, _sensePin, _ledPin, _buttonPin, _battPin, _usbSensePin;
   uint32_t _pwmFreq;
   uint8_t _pwmRes;
-  uint8_t _dutyMax;
+  uint16_t _dutyMax;
   uint8_t _level;
   bool _state;
   unsigned long _startTime;

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -156,11 +156,14 @@ public:
   // "charging on USB" for "dying on the cell". Presets set this; set it by hand
   // for a custom board.
   void setUsbSensePin(int8_t pin) { _usbSensePin = pin; }
-  // true when the load runs from USB (mux on VIN1). With no sense pin
-  // configured this returns true (fail safe: never blind-auto-shutdown).
+  // true when the load runs from USB (mux on VIN1). With no ST/USB-sense pin
+  // configured this is ALWAYS true (fail safe: a board that can't sense its
+  // source must never blind-auto-shut-down). Consequence: onBattery() is always
+  // false on pre-V0.4 boards, so gate low-battery logic on batteryState()
+  // (which handles the no-sense case), NOT on onBattery().
   bool usbPresent();
   // true when the load runs from the cell (mux on VIN2) — the only time
-  // readBatteryVolts() is a real state-of-charge.
+  // readBatteryVolts() is a real state-of-charge. Always false without an ST pin.
   bool onBattery() { return !usbPresent(); }
 
   // ------------------- battery (needs a battery pin) -------------------

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -12,6 +12,9 @@
 //   * Current sensing in real units (mA) with auto or manual calibration
 //   * Piezo-disc presence + water-level detection (probe + classifier)
 //   * Battery voltage monitoring (resistor divider) + low-battery helpers
+// v1.2 adds:
+//   * Power-source sensing via the TPS2116 mux ST pin (Battery Kit V0.4) so
+//     battery monitoring self-gates on USB-vs-cell and can't false-brown-out
 //
 // Hardware background: the boards sense piezo current through a shunt +
 // INA180A3 current-sense amplifier into an ADC pin. A dry disc, a missing
@@ -31,6 +34,7 @@ struct MistMakerPins {
   int8_t led;      // status LED (-1 = none)
   int8_t button;   // user button (-1 = none) — read it yourself, kept for reference
   int8_t battery;  // battery-voltage ADC via divider (-1 = none)
+  int8_t usbSense; // power-mux status (TPS2116 ST): HIGH=USB, LOW=cell (-1 = none)
 };
 
 // ---------------------------------------------------------------------------
@@ -43,22 +47,30 @@ struct MistMakerPins {
 // Mist Maker Extension (Seeed-Expansion) V0.1 — XIAO add-on, USB powered,
 // no battery, no boost-enable (piezo rail always on).
 inline MistMakerPins MistMakerExtensionV01() {
-  return MistMakerPins{ D0, -1, D2, -1, -1, -1 };
+  return MistMakerPins{ D0, -1, D2, -1, -1, -1, -1 };
 }
 
 // Mist Maker Battery Kit V0.3 — LiPo + USB-C, battery divider on D1.
+// No mux-status pin: on V0.3 the TPS2116 ST line isn't routed to the XIAO,
+// so battery reads can't tell USB from the cell — call disableBattery().
 inline MistMakerPins MistMakerBatteryKitV03() {
-  return MistMakerPins{ D0, D3, D2, D7, D6, D1 };
+  return MistMakerPins{ D0, D3, D2, D7, D6, D1, -1 };
+}
+
+// Mist Maker Battery Kit V0.4 — V0.3 plus the TPS2116 ST (power-mux status)
+// on D8, so battery monitoring gates itself on the real power source.
+inline MistMakerPins MistMakerBatteryKitV04() {
+  return MistMakerPins{ D0, D3, D2, D7, D6, D1, D8 };
 }
 
 // Block Kit V0.1 — OHS 2026 demo board (reed on D10, IS31FL3731 LEDs on I2C).
 inline MistMakerPins MistMakerBlockKitV01() {
-  return MistMakerPins{ D0, D3, D2, D7, D6, -1 };
+  return MistMakerPins{ D0, D3, D2, D7, D6, -1, -1 };
 }
 
 // Legacy V1.x single PCB (OHS 2025 workshop board).
 inline MistMakerPins MistMakerLegacyV1() {
-  return MistMakerPins{ D1, D3, D2, D7, D6, -1 };
+  return MistMakerPins{ D1, D3, D2, D7, D6, -1, -1 };
 }
 #endif
 
@@ -78,6 +90,7 @@ enum MistBatteryState : uint8_t {
   MIST_BATT_OK,
   MIST_BATT_LOW,            // below low threshold — warn the user
   MIST_BATT_CRITICAL,       // below cutoff — shut down gracefully NOW
+  MIST_BATT_CHARGING,       // on USB (mux on VIN1) — cell is charging, not a SoC
 };
 
 class MistMaker {
@@ -135,12 +148,30 @@ public:
   MistSenseState senseState() const { return _senseState; }
   float lastProbeMa() const { return _lastProbeMa; }
 
+  // ------------------- power source (mux status, V0.4+) -------------------
+  // The TPS2116 power mux picks USB (VIN1) over the cell (VIN2) whenever USB is
+  // present, so the battery is the *source* only when USB is unplugged. Its ST
+  // pin (HIGH = USB, LOW = cell) says which — wire it to a GPIO (Battery Kit
+  // V0.4 = D8) and battery monitoring gates itself on it, never mistaking
+  // "charging on USB" for "dying on the cell". Presets set this; set it by hand
+  // for a custom board.
+  void setUsbSensePin(int8_t pin) { _usbSensePin = pin; }
+  // true when the load runs from USB (mux on VIN1). With no sense pin
+  // configured this returns true (fail safe: never blind-auto-shutdown).
+  bool usbPresent();
+  // true when the load runs from the cell (mux on VIN2) — the only time
+  // readBatteryVolts() is a real state-of-charge.
+  bool onBattery() { return !usbPresent(); }
+
   // ------------------- battery (needs a battery pin) -------------------
-  // Turn battery sensing OFF at runtime. Battery Kit V0.3's D1 divider can't
-  // tell USB-C power from a real cell, so the reading is unreliable (it caused
-  // false low-battery shutdowns). After this call every battery_* method
-  // behaves exactly as on a board with no cell: readBatteryVolts()/percent()
-  // return 0 and batteryState() returns MIST_BATT_UNKNOWN (never CRITICAL).
+  // Turn battery sensing OFF at runtime — the pre-V0.4 escape hatch. Where the
+  // mux status isn't wired to a GPIO (Battery Kit V0.3), the D1 divider can't
+  // tell USB-C power from a real cell, so the reading is unreliable and caused
+  // false low-battery shutdowns. After this call every battery_* method behaves
+  // as on a board with no cell: readBatteryVolts()/percent() return 0 and
+  // batteryState() returns MIST_BATT_UNKNOWN. On V0.4 prefer wiring ST instead
+  // (setUsbSensePin / the V0.4 preset) — then batteryState() self-gates and you
+  // keep real monitoring while on the cell.
   void disableBattery() { _battPin = -1; }
   // Divider ratio = (Rtop+Rbottom)/Rbottom. Battery Kit V0.3 uses 2.0 (1:1).
   void setBatteryDivider(float ratio) { _battDivider = ratio; }
@@ -149,7 +180,9 @@ public:
   float readBatteryVolts(uint8_t samples = 16);
   // 0..100% rough LiPo state-of-charge estimate from voltage.
   uint8_t batteryPercent();
-  // Classified with hysteresis so it won't flap around the threshold.
+  // Classified with hysteresis so it won't flap around the threshold. With a
+  // USB-sense pin wired and USB present, returns MIST_BATT_CHARGING and never
+  // LOW/CRITICAL (the cell is a charge target, not the source).
   MistBatteryState batteryState();
   bool batteryLow()      { MistBatteryState s = batteryState();
                            return s == MIST_BATT_LOW || s == MIST_BATT_CRITICAL; }
@@ -163,7 +196,7 @@ private:
   float probeAtDuty(uint8_t duty, uint16_t settleMs, uint16_t sampleMs);
   void applyDuty(uint8_t duty);
 
-  int8_t _mistPin, _enPin, _sensePin, _ledPin, _buttonPin, _battPin;
+  int8_t _mistPin, _enPin, _sensePin, _ledPin, _buttonPin, _battPin, _usbSensePin;
   int _pwmFreq, _pwmRes, _dutyCycle;
   uint8_t _dutyMax;
   uint8_t _level;

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -6,15 +6,21 @@
 // ===========================================================================
 // MistMaker — Arduino library for the Programmable Mist Maker (OSHWA US002742)
 //
-// v1.1 adds (on top of shuang cai's v1.0 API, which is fully preserved):
-//   * Board pin presets for the official PCB variants
-//   * Mist dimming via setLevel(0..255)
-//   * Current sensing in real units (mA) with auto or manual calibration
-//   * Piezo-disc presence + water-level detection (probe + classifier)
-//   * Battery voltage monitoring (resistor divider) + low-battery helpers
-// v1.2 adds:
-//   * Power-source sensing via the TPS2116 mux ST pin (Battery Kit V0.4) so
-//     battery monitoring self-gates on USB-vs-cell and can't false-brown-out
+// One facade class + a pin preset per official board. Typical use:
+//
+//   MistMaker mist(MistMakerBatteryKitV04());
+//   void setup() { mist.begin(); mist.setLevel(180); }
+//
+// v2.0 — cleanup release:
+//   * every tuning value is a named constant in MistMakerDefaults (below)
+//   * constructor `duty` parameter now actually sets the duty cap (it was
+//     silently ignored in 1.x)
+//   * removed: applyLevel() alias -> use setLevel();
+//              readCurrentVoltage() -> use readCurrentMa()
+// v1.2   Power-source sensing via the TPS2116 mux ST pin (Battery Kit V0.4):
+//        battery monitoring self-gates on USB-vs-cell, can't false-brown-out.
+// v1.1   Board presets, dimming, current sensing in mA, disc/water detection,
+//        battery monitoring (on shuang cai's v1.0 control API).
 //
 // Hardware background: the boards sense piezo current through a shunt +
 // INA180A3 current-sense amplifier into an ADC pin. A dry disc, a missing
@@ -23,6 +29,41 @@
 // sensor for free. Default thresholds come from bench measurements on the
 // Block Kit V0.1 (XIAO ESP32-C6, INA180A3, 30 mOhm shunt, 2026-05).
 // ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Defaults — every tunable in one place. Constructor arguments and set*()
+// methods override these at runtime; edit here only to rebase the library
+// on different hardware.
+// ---------------------------------------------------------------------------
+namespace MistMakerDefaults {
+  // Piezo drive. 108.7 kHz = disc resonance; 8-bit duty; cap at 127 (50%)
+  // because beyond 50% the resonant push-pull gets weaker, not stronger.
+  constexpr uint32_t PWM_FREQ_HZ  = 108700;
+  constexpr uint8_t  PWM_RES_BITS = 8;
+  constexpr uint8_t  DUTY_MAX     = 127;
+
+  // Current sense: V per A = amp gain x shunt = INA180A3 (100 V/V) x 30 mOhm.
+  constexpr float SENSE_VOLTS_PER_AMP = 3.0f;
+
+  // Classifier thresholds (mA) — see autoCalibrateSense() for their meaning.
+  constexpr float TH_DISC_PRESENT_MA = 10.0f;   // >= this at probe duty -> disc there
+  constexpr float TH_WATER_LOW_MA    = 110.0f;  // <  this at water duty -> refill
+  constexpr float TH_DISC_DISCONN_MA = 70.0f;   // <  this at water duty -> disc fell off
+  constexpr uint8_t PROBE_DUTY       = 10;      // gentle presence-check duty
+  constexpr uint8_t WATER_PROBE_DUTY = 64;      // working duty for the water probe
+
+  // Battery. Divider ratio = (Rtop+Rbottom)/Rbottom — Battery Kits use
+  // 10k/10k = 2.0. Thresholds are volts UNDER LOAD; 50 mV hysteresis keeps
+  // batteryState() from flapping when the mist load sags the rail.
+  constexpr float BATT_DIVIDER      = 2.0f;
+  constexpr float BATT_LOW_V        = 3.45f;
+  constexpr float BATT_CRITICAL_V   = 3.20f;
+  constexpr float BATT_HYST_V       = 0.05f;
+  constexpr uint8_t BATT_SAMPLES    = 16;
+  // batteryPercent() linearizes this span (UI gauge only, not for cutoffs).
+  constexpr float BATT_EMPTY_V = 3.30f;
+  constexpr float BATT_FULL_V  = 4.20f;
+}
 
 // ---------------------------------------------------------------------------
 // Pin bundle. Use -1 for anything your board doesn't have.
@@ -75,7 +116,7 @@ inline MistMakerPins MistMakerLegacyV1() {
 #endif
 
 // ---------------------------------------------------------------------------
-// Sense classifier results
+// Classifier results
 // ---------------------------------------------------------------------------
 enum MistSenseState : uint8_t {
   MIST_SENSE_UNKNOWN = 0,   // no probe run yet (or no sense pin)
@@ -95,38 +136,39 @@ enum MistBatteryState : uint8_t {
 
 class MistMaker {
 public:
-  // --- v1.0 constructor (unchanged, backward compatible) ---
-  MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
-            int pwmFreq = 108700, int pwmRes = 8, int duty = 127);
-
-  // --- v1.1 constructor from a pin preset ---
+  // Pin-preset constructor (preferred). `dutyMax` caps the PWM duty that
+  // setLevel(255)/turnOn() reach — see MistMakerDefaults::DUTY_MAX.
   MistMaker(const MistMakerPins &pins,
-            int pwmFreq = 108700, int pwmRes = 8, int duty = 127);
+            uint32_t pwmFreq = MistMakerDefaults::PWM_FREQ_HZ,
+            uint8_t  pwmRes  = MistMakerDefaults::PWM_RES_BITS,
+            uint8_t  dutyMax = MistMakerDefaults::DUTY_MAX);
+
+  // Bare-pins constructor for breadboards / custom wiring (v1.0 signature).
+  MistMaker(int mistPin, int enPin, int sensePin, int ledPin,
+            uint32_t pwmFreq = MistMakerDefaults::PWM_FREQ_HZ,
+            uint8_t  pwmRes  = MistMakerDefaults::PWM_RES_BITS,
+            uint8_t  dutyMax = MistMakerDefaults::DUTY_MAX);
 
   void begin();
 
-  // ------------------- basic control (v1.0 API) -------------------
-  void turnOn();              // full power (dutyMax)
+  // ------------------- basic control -------------------
+  void turnOn();              // full power (= dutyMax)
   void turnOff();
   void toggle();
   bool isOn();
-  void printStatus();
-  float readCurrentVoltage(); // raw sense-pin voltage (kept for compat)
+  void printStatus();         // one status line to Serial
 
   // ------------------- dimming -------------------
   // level 0..255 maps linearly onto 0..dutyMax. 0 = off.
   void setLevel(uint8_t level);
-  void applyLevel(uint8_t level) { setLevel(level); } // alias (Ramping example)
   uint8_t getLevel() const { return _level; }
-  // dutyMax caps PWM duty (default 127 = 50% — the disc's sweet spot;
-  // beyond 50% the resonant push-pull gets weaker, not stronger).
   void setMaxDuty(uint8_t dutyMax) { _dutyMax = dutyMax; }
 
   // ------------------- current sensing -------------------
-  // Sense-amp transfer factor in V per A (gain x shunt).
-  // Default 3.0 = INA180A3 (100 V/V) x 30 mOhm. Change if your build differs.
+  // Sense-amp transfer factor in V per A (gain x shunt). Change if your
+  // build differs from MistMakerDefaults::SENSE_VOLTS_PER_AMP.
   void setCurrentSenseFactor(float voltsPerAmp) { _senseFactor = voltsPerAmp; }
-  // Mean current over `sampleMs` of continuous ADC reads, in mA.
+  // Mean current over `sampleMs` of continuous ADC reads, in mA. Blocking.
   float readCurrentMa(uint16_t sampleMs = 50);
 
   // Manual thresholds (mA). See autoCalibrateSense() for what they mean.
@@ -142,7 +184,8 @@ public:
   bool autoCalibrateSense();
 
   // Probe = briefly drive the disc at a probe duty, measure current,
-  // classify, then restore whatever the mist was doing before.
+  // classify, then restore whatever the mist was doing before. Blocking
+  // for a few hundred ms — schedule probes in an OFF window, not per-loop.
   MistSenseState probe();                 // full classify (disc + water)
   bool discPresent();                     // quick low-duty presence check
   MistSenseState senseState() const { return _senseState; }
@@ -176,11 +219,11 @@ public:
   // (setUsbSensePin / the V0.4 preset) — then batteryState() self-gates and you
   // keep real monitoring while on the cell.
   void disableBattery() { _battPin = -1; }
-  // Divider ratio = (Rtop+Rbottom)/Rbottom. Battery Kit V0.3 uses 2.0 (1:1).
+  // Divider ratio = (Rtop+Rbottom)/Rbottom. Battery Kits use 2.0 (10k/10k).
   void setBatteryDivider(float ratio) { _battDivider = ratio; }
-  // Thresholds in volts (defaults: low 3.45 V, critical 3.20 V under load).
+  // Thresholds in volts under load (defaults in MistMakerDefaults).
   void setBatteryThresholds(float lowV, float criticalV);
-  float readBatteryVolts(uint8_t samples = 16);
+  float readBatteryVolts(uint8_t samples = MistMakerDefaults::BATT_SAMPLES);
   // 0..100% rough LiPo state-of-charge estimate from voltage.
   uint8_t batteryPercent();
   // Classified with hysteresis so it won't flap around the threshold. With a
@@ -200,20 +243,20 @@ private:
   void applyDuty(uint8_t duty);
 
   int8_t _mistPin, _enPin, _sensePin, _ledPin, _buttonPin, _battPin, _usbSensePin;
-  int _pwmFreq, _pwmRes, _dutyCycle;
+  uint32_t _pwmFreq;
+  uint8_t _pwmRes;
   uint8_t _dutyMax;
   uint8_t _level;
   bool _state;
   unsigned long _startTime;
-  unsigned long _lastPrintTime;
 
   // current sense
   float _senseFactor;       // V per A
   float _thDiscPresentMa;   // above this at probe duty -> disc present
   float _thWaterLowMa;      // below this at water duty -> water low
   float _thDiscDisconnMa;   // below this at water duty -> disc fell off
-  uint8_t _probeDuty;       // low duty for presence probe (default 10)
-  uint8_t _waterProbeDuty;  // working duty for water probe (default 64)
+  uint8_t _probeDuty;       // low duty for presence probe
+  uint8_t _waterProbeDuty;  // working duty for water probe
   MistSenseState _senseState;
   float _lastProbeMa;
 

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -42,9 +42,14 @@
 // ---------------------------------------------------------------------------
 namespace MistMakerDefaults {
   // Piezo drive. 108.7 kHz = disc resonance. The duty cap defaults to 50% of
-  // full scale (127 at 8-bit) because beyond 50% the resonant push-pull gets
-  // weaker, not stronger. DUTY_AUTO = "resolve to that 50% for whatever
-  // resolution is configured"; any out-of-range cap resolves the same way.
+  // full scale (127 at 8-bit) — the efficiency/stability knee, NOT a mist
+  // maximum. Bench sweep (V0.4, 2026-07-03): mist keeps increasing past 50%,
+  // but drive current goes superlinear (224 mA @50% -> 1.1 A @75%), the
+  // autotransformer saturates and runs hot by ~62%, and total USB draw
+  // (~1.5 A @75%) sags VBUS into a brownout reset. Raise the cap past 127
+  // only deliberately: strong supply, short bursts, watch L1's temperature.
+  // DUTY_AUTO = "resolve to that 50% for whatever resolution is configured";
+  // any out-of-range cap resolves the same way.
   constexpr uint32_t PWM_FREQ_HZ  = 108700;
   constexpr uint8_t  PWM_RES_BITS = 8;
   constexpr int      DUTY_AUTO    = 0;
@@ -146,7 +151,8 @@ class MistMaker {
 public:
   // Pin-preset constructor (preferred). `dutyMax` caps the PWM duty that
   // setLevel(255)/turnOn() reach. Valid range 1..(2^pwmRes - 1); anything
-  // else (including DUTY_AUTO) = 50% of full scale, the resonant sweet spot.
+  // else (including DUTY_AUTO) = 50% of full scale, the efficiency knee
+  // (see the MistMakerDefaults note before driving past it).
   MistMaker(const MistMakerPins &pins,
             uint32_t pwmFreq = MistMakerDefaults::PWM_FREQ_HZ,
             uint8_t  pwmRes  = MistMakerDefaults::PWM_RES_BITS,


### PR DESCRIPTION
## MistMaker v2.0.0

Battery Kit **V0.4 support** + a full cleanup pass, bench-verified on real hardware and hardened by multi-angle review (Claude finder/verifier agents + Codex second-opinion pass — all confirmed findings applied).

### V0.4 power-source sensing
- `MistMakerBatteryKitV04()` preset — TPS2116 mux STATUS on **D8** (HIGH = USB, LOW = cell; verified against the V0.4 netlist + TI datasheet §7.3.3)
- `usbPresent()` / `onBattery()` + `MIST_BATT_CHARGING`: battery monitoring self-gates on the real source — the fix for V0.3's false low-battery shutdowns
- `readBatteryVolts()` uses calibrated `analogReadMilliVolts()`
- **V0.3 preset now ships with battery sensing OFF** (no ST pin = unreliable reads; forgetting `disableBattery()` was the footgun)
- Examples: real low-battery deep-sleep guards (2-strike CRITICAL, radio-off first)

### v2.0 cleanup
- Every tuning value named + documented in `namespace MistMakerDefaults` (public header = documentation)
- **Duty cap honored with a measured policy** (was silently ignored in 1.x): valid `1..90%` of full scale, higher clamps to 90% (above it the drive makes heat, not mist — bench sweep 2026-07-03), `DUTY_AUTO`/invalid → the 50% efficiency knee (exact 1.x behavior). `uint16_t` storage so >8-bit PWM works; `setMaxDuty()` applies mid-mist
- **`DUTY_TURBO` = 178 (~70% duty) — the bench-measured true mist maximum** as a named constant, with supply requirements documented
- Removed `applyLevel()` alias + `readCurrentVoltage()` (README documents the **unit change**: mA ≈ oldVolts × 166.7)
- README: migration guide, measured duty table, quick-start with V0.4 first

### Verification
- **All 10 examples × {XIAO_ESP32C6, XIAO_ESP32S3} compile clean** (CI matrix)
- Bench: full 0→90% duty sweeps on V0.4 + Extension boards across laptop USB / 2 A brick / charged cell

Companion PRs: #4 (stacked, phone sensors + music), Dav1dyang/Programmable-Mist-Maker#27 (hardware bring-up + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)