### PR TITLE
PhoneSensors: real JSON parsing + music mode rework (beat, log bands, auto-gain)

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -28,6 +28,7 @@ jobs:
             - source-path: ./        # this library
             - name: PubSubClient     # HomeAssistant_MQTT example
             - name: WebSockets       # PhoneSensors example (Markus Sattler)
+            - name: ArduinoJson      # PhoneSensors example (command parsing)
           sketch-paths: |
             - examples
           enable-warnings-report: true

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -25,12 +25,14 @@
 //   2. Fill in WIFI_SSID / WIFI_PASS / RELAY_HOST below.
 //   3. Flash. Open the app URL on your phone. Your maker appears in the list.
 //
-// Library: MistMaker >= 1.1.0  +  "WebSockets" by Markus Sattler (Library Mgr)
-// Board:   Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
+// Libraries (Library Manager): MistMaker >= 2.0.0,
+//   "WebSockets" by Markus Sattler, "ArduinoJson" by Benoit Blanchon (v7)
+// Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
 
 #include <MistMaker.h>
 #include <WiFi.h>
 #include <WebSocketsClient.h>
+#include <ArduinoJson.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
 MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
@@ -72,34 +74,38 @@ void applyMistPercent(int pct) {
   Serial.printf("[CMD] mist level -> %u%%\n", level);   // serial-debug each change
 }
 
-void sendStatus() {
+// All status fields are numbers or fixed strings, so snprintf is safe here;
+// parsing (below) uses a real JSON parser because the input is not ours.
+void sendStatus(float currentMa) {
   char buf[160];
   snprintf(buf, sizeof(buf),
     "{\"t\":\"status\",\"level\":%u,\"current_ma\":%.0f,\"water\":\"%s\",\"rssi\":%d}",
-    level, mist.readCurrentMa(20), waterName(mist.senseState()), WiFi.RSSI());
+    level, currentMa, waterName(mist.senseState()), WiFi.RSSI());
   ws.sendTXT(buf);
 }
 
 // Commands from the phone:
 //   {"t":"set","target":"all"|"<id>","level":NN}   one or all makers
 //   {"t":"multi","levels":{"<id>":NN,...}}         a different level per maker
-void onCommand(const char* msg) {
-  if (strstr(msg, "\"t\":\"set\"")) {
-    const char* tgt = strstr(msg, "\"target\":\"");
-    bool forMe = !tgt;                                  // no target = everyone
-    if (tgt) {
-      tgt += 10;                                        // step over: "target":"
-      const size_t n = strlen(deviceId);
-      forMe = !strncmp(tgt, "all\"", 4) ||
-              (!strncmp(tgt, deviceId, n) && tgt[n] == '"');  // exact id, not a prefix
+void onCommand(const char* msg, size_t len) {
+  JsonDocument doc;                                    // ArduinoJson v7: elastic
+  if (deserializeJson(doc, msg, len)) return;          // not JSON — ignore
+  const char* t = doc["t"];
+  if (!t) return;
+
+  if (!strcmp(t, "set")) {
+    const char* tgt = doc["target"];                   // missing target = everyone
+    const bool forMe = !tgt || !strcmp(tgt, "all") || !strcmp(tgt, deviceId);
+    if (forMe && doc["level"].is<int>()) {
+      lastCmd = millis();
+      applyMistPercent(doc["level"].as<int>());
     }
-    const char* lv = strstr(msg, "\"level\":");
-    if (forMe && lv) { lastCmd = millis(); applyMistPercent(atoi(lv + 8)); }
-  } else if (strstr(msg, "\"t\":\"multi\"")) {
-    char key[10];
-    snprintf(key, sizeof(key), "\"%s\":", deviceId);    // find "A4F1":NN
-    const char* p = strstr(msg, key);
-    if (p) { lastCmd = millis(); applyMistPercent(atoi(p + strlen(key))); }
+  } else if (!strcmp(t, "multi")) {
+    JsonVariant mine = doc["levels"][deviceId];
+    if (!mine.isNull()) {
+      lastCmd = millis();
+      applyMistPercent(mine.as<int>());
+    }
   }
 }
 
@@ -116,7 +122,7 @@ void onWsEvent(WStype_t type, uint8_t* payload, size_t len) {
       Serial.println("[WS] error");
       break;
     case WStype_TEXT:
-      onCommand((const char*)payload);
+      onCommand((const char*)payload, len);
       break;
     default: break;
   }
@@ -185,12 +191,13 @@ void loop() {
   }
 
   // Once a second: report status to the app AND print a Serial heartbeat.
+  // One shared reading — readCurrentMa blocks for its sample window.
   if (millis() - lastTick > 1000) {
     lastTick = millis();
     const float ma = mist.readCurrentMa(20);
     Serial.printf("[STAT] level=%u%%  current=%.0f mA  water=%s  wifi=%s(%d dBm)\n",
                   level, ma, waterName(mist.senseState()),
                   ws.isConnected() ? "relay-ok" : "no-relay", WiFi.RSSI());
-    if (ws.isConnected()) sendStatus();
+    if (ws.isConnected()) sendStatus(ma);
   }
 }

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -88,21 +88,26 @@ void sendStatus(float currentMa) {
 //   {"t":"set","target":"all"|"<id>","level":NN}   one or all makers
 //   {"t":"multi","levels":{"<id>":NN,...}}         a different level per maker
 void onCommand(const char* msg, size_t len) {
+  if (len > 384) return;                               // valid commands are tiny
   JsonDocument doc;                                    // ArduinoJson v7: elastic
   if (deserializeJson(doc, msg, len)) return;          // not JSON — ignore
   const char* t = doc["t"];
   if (!t) return;
 
   if (!strcmp(t, "set")) {
-    const char* tgt = doc["target"];                   // missing target = everyone
+    // target must be absent (= everyone) or a string naming us/"all";
+    // a malformed non-string target must NOT read as "everyone".
+    JsonVariant tv = doc["target"];
+    if (!tv.isNull() && !tv.is<const char*>()) return;
+    const char* tgt = tv.as<const char*>();
     const bool forMe = !tgt || !strcmp(tgt, "all") || !strcmp(tgt, deviceId);
     if (forMe && doc["level"].is<int>()) {
       lastCmd = millis();
-      applyMistPercent(doc["level"].as<int>());
+      applyMistPercent(doc["level"].as<int>());        // constrained 0..100 inside
     }
   } else if (!strcmp(t, "multi")) {
     JsonVariant mine = doc["levels"][deviceId];
-    if (!mine.isNull()) {
+    if (mine.is<int>()) {
       lastCmd = millis();
       applyMistPercent(mine.as<int>());
     }

--- a/extras/phone-app/README.md
+++ b/extras/phone-app/README.md
@@ -134,7 +134,12 @@ Open your Worker URL on a phone, then:
   - **Tilt** 📱 — lean the phone left/right.
   - **Face** 😮 — open your mouth (or switch to brows / blink).
   - **Music** 🎵 — play a song; the makers become a **spectrum** — one frequency
-    band each. Line them up for a vapor equalizer.
+    band each (log-spaced 60 Hz–8 kHz, so bass gets real resolution). Bands
+    auto-gain against their own rolling peaks, ride a fast-attack/slow-release
+    envelope, and a bass beat detector adds a decaying "punch" on each kick — the
+    mist pulses with the rhythm instead of tracking raw loudness. Band order
+    follows device id, so each maker keeps its band across reconnects. Line them
+    up for a vapor equalizer.
 - **Your makers** — with 2+ makers you get routing:
   - **Together** — all in sync.
   - **Wave** — a ripple/delay across them (use *spread*) — an animation.

--- a/extras/phone-app/public/app.js
+++ b/extras/phone-app/public/app.js
@@ -309,7 +309,11 @@ const Audio = {
     this.prevBass = bass;
     this.fluxAvg += (flux - this.fluxAvg) * 0.05;
     this.fluxDev += (Math.abs(flux - this.fluxAvg) - this.fluxDev) * 0.05;
-    if (flux > this.fluxAvg + 2 * this.fluxDev && this.beat < 0.3) this.beat = 1;
+    // absolute floor: bass must carry real signal (~24/255 mean per bin), or
+    // post-silence mic noise fires phantom beats
+    const bassBins = Math.max(3, e[Math.min(2, N)] - e[0]);
+    const bassFloor = bassBins * 24;
+    if (bass > bassFloor && flux > this.fluxAvg + 2 * this.fluxDev && this.beat < 0.3) this.beat = 1;
     this.beat *= 0.90;                                  // ~150 ms decay at 60 fps
 
     for (let i = 0; i < N; i++) {
@@ -324,7 +328,7 @@ const Audio = {
       out[i] = clamp((this.env[i] * 100 + this.beat * 20) * G());
     }
     bands = out;
-    energy = clamp(out.reduce((p, c) => p + c, 0) / N + this.beat * 30);
+    energy = clamp(out.reduce((p, c) => p + c, 0) / N + this.beat * 30 * Math.min(1, G()));
     drawBands(this.ctx2d, out, this.beat);
   },
   stop() { teardown(this.a); this.a = null; bands = null; bandsCv.hidden = true;

--- a/extras/phone-app/public/app.js
+++ b/extras/phone-app/public/app.js
@@ -89,11 +89,14 @@ function dispatch() {
     if (force || isNew(key, lvl)) { wsSend({ t: "set", target: tgt, level: lvl }); seen.set(key, lvl); lastSendAt = now; }
   } else {
     const levels = {};
+    // Sort by id so band/wave position is deterministic — a maker keeps its
+    // frequency band across reconnects instead of following roster order.
+    const orderly = [...makers].sort((a, b) => (a.id < b.id ? -1 : 1));
     if (route === "spectrum") {   // bands present here (the null case fell into sync above)
-      makers.forEach((d, i) => levels[d.id] = Math.round(bands[i % bands.length] || 0));
+      orderly.forEach((d, i) => levels[d.id] = Math.round(bands[i % bands.length] || 0));
     } else { // phase: a traveling wave scaled by the input energy
       const sp = (spread.value / 100) * Math.PI;
-      makers.forEach((d, i) => levels[d.id] = Math.round(energy * (0.5 + 0.5 * Math.sin(waveT - i * sp))));
+      orderly.forEach((d, i) => levels[d.id] = Math.round(energy * (0.5 + 0.5 * Math.sin(waveT - i * sp))));
     }
     let any = force;
     for (const id in levels) if (isNew("m:" + id, levels[id])) any = true;
@@ -258,28 +261,71 @@ const Face = {
   stop() { teardown({ stream: this.stream }); this.fl?.close?.(); this.fl = null; this.picker?.remove(); this.picker = null; },
 };
 
+/* Music mode. Four ideas beyond "volume = mist":
+   1. LOG-SPACED bands (60 Hz–8 kHz): musical octaves, so bass gets real
+      resolution instead of one linear slice. FFT 2048 → ~21.5 Hz bins.
+   2. Per-band AUTO-GAIN: each band normalizes against its own rolling peak,
+      so a quiet hi-hat band dances as much as a loud kick band.
+   3. ATTACK/RELEASE envelope: rises fast on a hit, falls slowly — the 8 Hz
+      send layer samples a smooth curve instead of FFT jitter.
+   4. BEAT PUNCH: spectral flux on the bass bands; when a kick lands, energy
+      (and every band a little) gets a decaying boost, so even the single-
+      maker "sync" route visibly pulses with the music. */
 const Audio = {
-  name: "audio", hint: "Play music near the phone — each maker becomes one frequency band.",
+  name: "audio", hint: "Play music near the phone — makers pulse with the beat, one frequency band each.",
   async start() {
-    this.a = await micAnalyser(256); this.buf = new Uint8Array(this.a.an.frequencyBinCount);
+    this.a = await micAnalyser(2048);
+    this.a.an.smoothingTimeConstant = 0.5;   // snappier than the 0.8 default; we do our own envelope
+    this.buf = new Uint8Array(this.a.an.frequencyBinCount);
+    this.env = []; this.ref = [];            // per-band envelope + rolling peak (auto-gain)
+    this.prevBass = 0; this.beat = 0; this.fluxAvg = 0; this.fluxDev = 1;
     bandsCv.hidden = false; this.ctx2d = bandsCv.getContext("2d");
     bandsCv.width = (bandsCv.clientWidth || 320) * devicePixelRatio; bandsCv.height = 70 * devicePixelRatio;
     if (makers.length >= 2) { this.prevRoute = route; setRoute("spectrum"); }
+  },
+  // Log-spaced band edges (FFT bin indexes) for N bands over 60 Hz..8 kHz.
+  edges(N) {
+    const sr = this.a.an.context.sampleRate;
+    if (this._e?.length === N + 1 && this._sr === sr) return this._e;
+    const hzPerBin = sr / this.a.an.fftSize, hi = Math.min(8000, sr / 2);
+    this._e = Array.from({ length: N + 1 },
+      (_, i) => Math.max(1, Math.round(60 * Math.pow(hi / 60, i / N) / hzPerBin)));
+    for (let i = 1; i <= N; i++)                        // ≥1 bin per band
+      if (this._e[i] <= this._e[i - 1]) this._e[i] = this._e[i - 1] + 1;
+    this._sr = sr;
+    return this._e;
   },
   read() {
     if (!this.a) return;
     this.a.an.getByteFrequencyData(this.buf);
     const N = Math.max(1, Math.min(makers.length || 8, 16));
-    const out = new Array(N).fill(0);
-    const lo = 2, hi = this.buf.length;                  // skip DC bin
+    const e = this.edges(N), out = new Array(N);
+
+    // Beat: spectral flux (energy rising frame-over-frame) in the bass bins,
+    // fired when it clears its own rolling mean + 2 sigma. Self-calibrating.
+    let bass = 0;
+    for (let j = e[0]; j < Math.max(e[0] + 3, e[Math.min(2, N)]); j++) bass += this.buf[j];
+    const flux = Math.max(0, bass - this.prevBass);
+    this.prevBass = bass;
+    this.fluxAvg += (flux - this.fluxAvg) * 0.05;
+    this.fluxDev += (Math.abs(flux - this.fluxAvg) - this.fluxDev) * 0.05;
+    if (flux > this.fluxAvg + 2 * this.fluxDev && this.beat < 0.3) this.beat = 1;
+    this.beat *= 0.90;                                  // ~150 ms decay at 60 fps
+
     for (let i = 0; i < N; i++) {
-      const a = lo + Math.floor((hi - lo) * i / N), b = lo + Math.floor((hi - lo) * (i + 1) / N);
-      let s = 0; for (let j = a; j < b; j++) s += this.buf[j];
-      out[i] = clamp((s / Math.max(1, b - a)) / 255 * 140 * G());
+      let s = 0; for (let j = e[i]; j < e[i + 1]; j++) s += this.buf[j];
+      const raw = (s / (e[i + 1] - e[i])) / 255;        // 0..1
+      // auto-gain: normalize to this band's own slowly-decaying peak
+      this.ref[i] = Math.max(raw, (this.ref[i] || 0.25) * 0.998, 0.25);
+      const norm = Math.min(1, raw / this.ref[i]);
+      // envelope: fast attack, slow release
+      const prev = this.env[i] || 0;
+      this.env[i] = prev + (norm - prev) * (norm > prev ? 0.5 : 0.12);
+      out[i] = clamp((this.env[i] * 100 + this.beat * 20) * G());
     }
     bands = out;
-    energy = out.reduce((p, c) => p + c, 0) / N;
-    drawBands(this.ctx2d, out);
+    energy = clamp(out.reduce((p, c) => p + c, 0) / N + this.beat * 30);
+    drawBands(this.ctx2d, out, this.beat);
   },
   stop() { teardown(this.a); this.a = null; bands = null; bandsCv.hidden = true;
            if (this.prevRoute) { setRoute(this.prevRoute); this.prevRoute = null; } },
@@ -290,9 +336,13 @@ const SOURCES = { mic: Mic, light: Light, motion: Motion, face: Face, audio: Aud
 function teardown(a) { try { a?.stream?.getTracks().forEach(t => t.stop()); a?.ctx?.close?.(); } catch {} }
 function clamp(v) { return v < 0 ? 0 : v > 100 ? 100 : v; }
 
-function drawBands(cx, arr) {
+function drawBands(cx, arr, beat = 0) {
   const W = bandsCv.width, H = bandsCv.height, n = arr.length, bw = W / n;
   cx.clearRect(0, 0, W, H);
+  if (beat > 0.05) {                       // beat flash behind the bars
+    cx.fillStyle = `rgba(255, 200, 49, ${(beat * 0.25).toFixed(3)})`;
+    cx.fillRect(0, 0, W, H);
+  }
   arr.forEach((v, i) => {
     const h = (v / 100) * H;
     cx.fillStyle = i % 2 ? "#2596be" : "#ffc831";


### PR DESCRIPTION
## What

Stacked on #3 (library v2.0). Improves the phone-sensor demo's firmware robustness and gives **music mode** an actual musical ear.

### Firmware (`examples/PhoneSensors`)
- Commands parsed with **ArduinoJson v7** instead of `strstr`/`atoi` — the old scan depended on the phone's exact whitespace-free serialization and broke silently otherwise. CI now installs ArduinoJson.
- Status tick takes one shared current reading (was two 20 ms blocking reads per second).

### Music mode (`extras/phone-app/public/app.js`)
| Before | After |
|---|---|
| 256-pt FFT, linear band split (bass ≈ 1 bin) | **2048-pt FFT, log-spaced bands 60 Hz–8 kHz** (musical octaves) |
| Raw magnitude × fixed gain | **Per-band auto-gain** against a rolling peak + **fast-attack/slow-release envelope** |
| Volume-only response | **Bass spectral-flux beat detector** (self-calibrating μ+2σ) adds a decaying punch — mist pulses on the kick even with one maker |
| Band assigned by roster arrival order | **Sorted by device id** — a maker keeps its band across reconnects (also makes the wave route deterministic) |

Visualizer gets a beat flash; READMEs updated.

**Not deployed**: the live `mistcontrol.byproductlab.com` worker is untouched — try it locally / on a preview first, then `wrangler deploy` when happy (only `public/app.js` changed; the worker itself is untouched).

## Verification
- PhoneSensors compiles for XIAO_ESP32C6 + XIAO_ESP32S3
- `node --check` clean on app.js
- End-to-end phone test needs a phone + mic permission — not exercised here

🤖 Generated with [Claude Code](https://claude.com/claude-code)