### PR TITLE
v2.1.0 — Battery Kit V0.4.1 preset, MISTMAKER_VERSION, keywords.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 - **Current sensing in mA** with auto or manual calibration
 - **Piezo disc + water detection** — one ADC pin tells you if a disc is attached, if it fell off, and if the water ran out
 - **Battery monitoring** — calibrated voltage, percent estimate, and a graceful low-battery shutdown to prevent brown-outs
-- **Power-source sensing** — reads the TPS2116 mux status (Battery Kit V0.4) so battery logic knows USB from the cell and never false-triggers
+- **Power-source sensing** — reads the TPS2116 mux status (Battery Kit V0.4+) so battery logic knows USB from the cell and never false-triggers
 - **Pin presets for every official board variant** — one line to target your PCB
 - Designed for ESP32-based boards (tested on Seeed Studio XIAO ESP32-C6)
 - Modular and reusable class-based structure
+
+> **New in v2.1:** `MistMakerBatteryKitV041()` preset for the July 2026
+> production board (same pins as V0.4 — the spin changed passives only), the
+> `MISTMAKER_VERSION` string for banners/test reports, and `keywords.txt`
+> (IDE syntax highlighting). No API changes — 2.0 sketches compile unchanged.
 
 > **Upgrading to v2.0?**
 > - `applyLevel(x)` → `setLevel(x)` (true rename, same 0..255 meaning).
@@ -49,7 +54,7 @@ This project is [Open Source Hardware Certified](https://certification.oshwa.org
 #include <MistMaker.h>
 
 // One line per board — pick yours:
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // current production board (V0.4: same pins — either works)
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off — no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());
@@ -151,10 +156,10 @@ calibrated `analogReadMilliVolts()` (linear even on the C6).
 > state-of-charge) on USB — reading it blindly caused false low-battery
 > shutdowns.
 >
-> - **Battery Kit V0.4** routes the mux **ST** (status) pin to **D8**, so the
->   `MistMakerBatteryKitV04()` preset self-gates: `batteryState()` returns
->   `MIST_BATT_CHARGING` on USB and only ever reports `LOW`/`CRITICAL` on the
->   cell. Use `usbPresent()` / `onBattery()` to read the source yourself.
+> - **Battery Kit V0.4 / V0.4.1** route the mux **ST** (status) pin to **D8**, so
+>   the `MistMakerBatteryKitV041()` / `...V04()` presets self-gate: `batteryState()`
+>   returns `MIST_BATT_CHARGING` on USB and only ever reports `LOW`/`CRITICAL` on
+>   the cell. Use `usbPresent()` / `onBattery()` to read the source yourself.
 > - **Battery Kit V0.3** has no ST pin, so its preset ships with battery
 >   sensing **off** (every `battery*` call behaves as on a board with no
 >   cell). `disableBattery()` remains for switching it off at runtime on
@@ -254,7 +259,7 @@ MistSenseState senseState();
 float lastProbeMa();
 
 // --- power source (mux status, V0.4+) ---
-void    setUsbSensePin(int8_t pin);                // TPS2116 ST (Battery Kit V0.4 = D8)
+void    setUsbSensePin(int8_t pin);                // TPS2116 ST (Battery Kit V0.4+ = D8)
 bool    usbPresent();            // load on USB (mux VIN1)? true if no sense pin
 bool    onBattery();             // load on the cell (mux VIN2)? = valid SoC
 

--- a/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
+++ b/examples/HomeAssistant_MQTT/HomeAssistant_MQTT.ino
@@ -15,7 +15,7 @@
 // Requirements:
 //   * MQTT broker (the standard Mosquitto add-on) + MQTT integration in HA
 //   * Arduino library: PubSubClient (Library Manager)
-//   * MistMaker >= 2.0.0
+//   * MistMaker >= 2.1.0
 //
 // Prefer YAML/no-code? See the ESPHome config in the main repo:
 // Programmable-Mist-Maker/firmware-examples/home-assistant/esphome-mistmaker.yaml
@@ -28,7 +28,7 @@
 #include <esp_sleep.h>          // deep sleep on a critically low cell
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // V0.4/V0.4.1: ST on D8 gates battery vs USB
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());

--- a/examples/MistBlink/MistBlink.ino
+++ b/examples/MistBlink/MistBlink.ino
@@ -7,12 +7,12 @@
 // preset that matches your PCB below.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 2.0.0
+// Library: MistMaker >= 2.1.0
 
 #include <MistMaker.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // V0.4/V0.4.1: ST on D8 gates battery vs USB
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());

--- a/examples/MistDimming/MistDimming.ino
+++ b/examples/MistDimming/MistDimming.ino
@@ -8,13 +8,13 @@
 // like the Block Kit's wave mode.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 2.0.0
+// Library: MistMaker >= 2.1.0
 
 #include <MistMaker.h>
 #include <math.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // V0.4/V0.4.1: ST on D8 gates battery vs USB
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());

--- a/examples/PhoneSensors/PhoneSensors.ino
+++ b/examples/PhoneSensors/PhoneSensors.ino
@@ -25,7 +25,7 @@
 //   2. Fill in WIFI_SSID / WIFI_PASS / RELAY_HOST below.
 //   3. Flash. Open the app URL on your phone. Your maker appears in the list.
 //
-// Libraries (Library Manager): MistMaker >= 2.0.0,
+// Libraries (Library Manager): MistMaker >= 2.1.0,
 //   "WebSockets" by Markus Sattler, "ArduinoJson" by Benoit Blanchon (v7)
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
 
@@ -35,7 +35,7 @@
 #include <ArduinoJson.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // V0.4/V0.4.1: ST on D8 gates battery vs USB
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());

--- a/examples/WaterDetect/WaterDetect.ino
+++ b/examples/WaterDetect/WaterDetect.ino
@@ -17,12 +17,12 @@
 // the disc is missing or the water runs out; refill/reattach and it resumes.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 2.0.0
+// Library: MistMaker >= 2.1.0
 
 #include <MistMaker.h>
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // V0.4/V0.4.1: ST on D8 gates battery vs USB
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());

--- a/examples/WiFiPhoneControl/WiFiPhoneControl.ino
+++ b/examples/WiFiPhoneControl/WiFiPhoneControl.ino
@@ -16,7 +16,7 @@
 // pin) switch the preset below — its preset ships with battery sensing off.
 //
 // Board: Seeed XIAO ESP32-C6 (select XIAO_ESP32C6 in Tools > Board)
-// Library: MistMaker >= 2.0.0
+// Library: MistMaker >= 2.1.0
 
 #include <MistMaker.h>
 #include <WiFi.h>
@@ -24,7 +24,7 @@
 #include <esp_sleep.h>          // deep sleep on a critically low cell
 
 // ---- Select your board (uncomment exactly ONE) ----
-MistMaker mist(MistMakerBatteryKitV04());   // V0.4 board: ST on D8 gates battery vs USB
+MistMaker mist(MistMakerBatteryKitV041());  // V0.4/V0.4.1: ST on D8 gates battery vs USB
 // MistMaker mist(MistMakerBatteryKitV03()); // V0.3 board (battery sensing off - no ST pin)
 // MistMaker mist(MistMakerExtensionV01());
 // MistMaker mist(MistMakerBlockKitV01());

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,74 @@
+#######################################
+# Syntax Coloring Map for MistMaker
+# (fields are TAB-separated — required by the IDE)
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+MistMaker	KEYWORD1
+MistMakerPins	KEYWORD1
+MistSenseState	KEYWORD1
+MistBatteryState	KEYWORD1
+MistMakerDefaults	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+turnOn	KEYWORD2
+turnOff	KEYWORD2
+toggle	KEYWORD2
+isOn	KEYWORD2
+printStatus	KEYWORD2
+setLevel	KEYWORD2
+getLevel	KEYWORD2
+setMaxDuty	KEYWORD2
+setCurrentSenseFactor	KEYWORD2
+readCurrentMa	KEYWORD2
+setSenseThresholds	KEYWORD2
+autoCalibrateSense	KEYWORD2
+probe	KEYWORD2
+discPresent	KEYWORD2
+senseState	KEYWORD2
+lastProbeMa	KEYWORD2
+setUsbSensePin	KEYWORD2
+usbPresent	KEYWORD2
+onBattery	KEYWORD2
+disableBattery	KEYWORD2
+setBatteryDivider	KEYWORD2
+setBatteryThresholds	KEYWORD2
+readBatteryVolts	KEYWORD2
+batteryPercent	KEYWORD2
+batteryState	KEYWORD2
+batteryLow	KEYWORD2
+batteryCritical	KEYWORD2
+shutdown	KEYWORD2
+MistMakerExtensionV01	KEYWORD2
+MistMakerBatteryKitV03	KEYWORD2
+MistMakerBatteryKitV04	KEYWORD2
+MistMakerBatteryKitV041	KEYWORD2
+MistMakerBlockKitV01	KEYWORD2
+MistMakerLegacyV1	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+MISTMAKER_VERSION	LITERAL1
+MIST_SENSE_UNKNOWN	LITERAL1
+MIST_DISC_MISSING	LITERAL1
+MIST_WATER_OK	LITERAL1
+MIST_WATER_LOW	LITERAL1
+MIST_DISC_DISCONNECTED	LITERAL1
+MIST_BATT_UNKNOWN	LITERAL1
+MIST_BATT_OK	LITERAL1
+MIST_BATT_LOW	LITERAL1
+MIST_BATT_CRITICAL	LITERAL1
+MIST_BATT_CHARGING	LITERAL1
+PWM_FREQ_HZ	LITERAL1
+PWM_RES_BITS	LITERAL1
+DUTY_AUTO	LITERAL1
+DUTY_TURBO	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=MistMaker
-version=2.0.0
+version=2.1.0
 author=shuang cai, David Yang
 maintainer=shuangcai64@gmail.com
 sentence=A library to control a mist maker under OSHWA ID US002742 with PWM, current sensing, and battery monitoring.
-paragraph=Encapsulates mist maker control functions: 108.7kHz PWM with dimming, piezo current sensing with auto/manual calibration, disc and water-level detection, battery voltage monitoring with USB-vs-cell power-source detection (mux status) and graceful low-battery shutdown, and pin presets for all official Programmable Mist Maker PCB variants.
+paragraph=Encapsulates mist maker control functions: 108.7kHz PWM with dimming, piezo current sensing with auto/manual calibration, disc and water-level detection, battery voltage monitoring with USB-vs-cell power-source detection (mux status) and graceful low-battery shutdown, and pin presets for all official Programmable Mist Maker PCB variants (through Battery Kit V0.4.1, the July 2026 production board).
 category=Signal Input/Output
 url=https://github.com/Dav1dyang/Programmable-Mist-Maker
 architectures=esp32

--- a/src/MistMaker.h
+++ b/src/MistMaker.h
@@ -3,6 +3,10 @@
 
 #include <Arduino.h>
 
+// Library version — keep in lockstep with library.properties. Sketches can
+// print it in banners/test reports: Serial.println(MISTMAKER_VERSION);
+#define MISTMAKER_VERSION "2.1.0"
+
 // ===========================================================================
 // MistMaker — Arduino library for the Programmable Mist Maker (OSHWA US002742)
 //
@@ -11,6 +15,10 @@
 //   MistMaker mist(MistMakerBatteryKitV04());
 //   void setup() { mist.begin(); mist.setLevel(180); }
 //
+// v2.1   Battery Kit V0.4.1 (July 2026 production run): new preset
+//        MistMakerBatteryKitV041() — same pin map as V0.4, the spin changed
+//        passives only (D8 USB-high now ~3.1 V, boost rail boots OFF).
+//        Adds MISTMAKER_VERSION and keywords.txt. No API changes.
 // v2.0 — cleanup release:
 //   * hardware tuning values are named constants in MistMakerDefaults (below);
 //     probe/calibration timing lives at the top of MistMaker.cpp
@@ -123,6 +131,15 @@ inline MistMakerPins MistMakerBatteryKitV03() {
 // on D8, so battery monitoring gates itself on the real power source.
 inline MistMakerPins MistMakerBatteryKitV04() {
   return MistMakerPins{ D0, D3, D2, D7, D6, D1, D8 };
+}
+
+// Mist Maker Battery Kit V0.4.1 — the July 2026 production spin (the boards
+// sold assembled). Same pin map as V0.4; the changes were passive (R22 220k
+// stiffens D8's USB-high to ~3.1 V, R8 pull-down boots the ~5 V rail OFF,
+// R7 dims LED2), so the two presets are interchangeable — this one exists so
+// a sketch can name the revision printed on its silkscreen.
+inline MistMakerPins MistMakerBatteryKitV041() {
+  return MistMakerBatteryKitV04();
 }
 
 // Block Kit V0.1 — OHS 2026 demo board (reed on D10, IS31FL3731 LEDs on I2C).


### PR DESCRIPTION
## What

Library counterpart to Programmable-Mist-Maker PR #30 (V0.4.1 board-in-hand).

- **`MistMakerBatteryKitV041()`** — preset for the July 2026 production board. Electrically identical pin map to V0.4 (the spin was passive-only: R22 220k → D8 USB-high ~3.1 V, R8 pull-down → 5 V rail boots off, R7 → LED2 dimming), so it delegates to `MistMakerBatteryKitV04()`; it exists so a sketch can name the revision on its silkscreen.
- **`MISTMAKER_VERSION`** ("2.1.0") — for banners/test reports alongside the bring-up self-test's own fw version.
- **`keywords.txt`** — the library had none, so the IDE highlighted nothing. Full map added (types, all public methods, presets, enum constants, `DUTY_TURBO`/`DUTY_AUTO`).
- Examples default to the V041 preset; requirement comments bumped to ≥ 2.1.0. README gains the v2.1 note. No API changes — 2.0 sketches compile unchanged.

## Verification

All 10 examples compile for `esp32:esp32:XIAO_ESP32C6` (core 3.3.10) against this tree via `--library` (bypassing the stale v1.1.0 copy in `~/Documents/Arduino/libraries`). CI runs the same matrix plus S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176UKZKuBVRY94h7e6Rjaiu
